### PR TITLE
[feat/#12] API 공통 응답 객체 및 에러 핸들러 구현

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -1,0 +1,9 @@
+package com.tuk.oriddle.global.error
+
+enum class ErrorCode(val status: Int, val code: String, val message: String) {
+    // 도메인 별로 나눠서 관리
+    // Global
+    INTERNAL_SERVER_ERROR(500, "GL0001", "서버 오류"),
+    INPUT_INVALID_VALUE(409, "GL0002", "잘못된 입력"),
+    ;
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorResponse.kt
@@ -1,0 +1,37 @@
+package com.tuk.oriddle.global.error
+
+import org.springframework.validation.BindingResult
+
+data class ErrorResponse private constructor(
+    val businessCode: String,
+    val errorMessage: String,
+    val errors: List<FieldError> = listOf()
+) {
+    companion object {
+        fun of(code: ErrorCode, bindingResult: BindingResult): ErrorResponse {
+            val fieldErrors = bindingResult.fieldErrors.map { error ->
+                FieldError(
+                    field = error.field,
+                    value = error.rejectedValue?.toString() ?: "",
+                    reason = error.defaultMessage ?: ""
+                )
+            }
+            return ErrorResponse(
+                businessCode = code.code,
+                errorMessage = code.message,
+                errors = fieldErrors
+            )
+        }
+
+        fun of(code: ErrorCode): ErrorResponse = ErrorResponse(
+            businessCode = code.code,
+            errorMessage = code.message
+        )
+    }
+
+    data class FieldError(
+        val field: String,
+        val value: String,
+        val reason: String
+    )
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/GlobalExceptionHandler.kt
@@ -1,0 +1,36 @@
+package com.tuk.oriddle.global.error
+
+import com.tuk.oriddle.global.error.exception.BusinessException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @ExceptionHandler(Exception::class)
+    protected fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        log.error(e.message, e)
+        val response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR)
+        return ResponseEntity(response, HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    protected fun handleRuntimeException(e: BusinessException): ResponseEntity<ErrorResponse> {
+        val errorCode = e.errorCode
+        val response = ErrorResponse.of(errorCode)
+        log.warn(e.message)
+        return ResponseEntity.status(errorCode.status).body(response)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    protected fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val response = ErrorResponse.of(ErrorCode.INPUT_INVALID_VALUE, e.bindingResult)
+        log.warn(e.message)
+        return ResponseEntity.status(ErrorCode.INPUT_INVALID_VALUE.status).body(response)
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/error/exception/BusinessException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/exception/BusinessException.kt
@@ -2,4 +2,4 @@ package com.tuk.oriddle.global.error.exception
 
 import com.tuk.oriddle.global.error.ErrorCode
 
-class BusinessException(val errorCode: ErrorCode) : RuntimeException(errorCode.message)
+open class BusinessException(val errorCode: ErrorCode) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/tuk/oriddle/global/error/exception/BusinessException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/exception/BusinessException.kt
@@ -1,0 +1,5 @@
+package com.tuk.oriddle.global.error.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+
+class BusinessException(val errorCode: ErrorCode) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
@@ -1,0 +1,6 @@
+package com.tuk.oriddle.global.result
+
+enum class ResultCode(val code: String, val message: String) {
+    // 도메인 별로 나눠서 관리
+    ;
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultResponse.kt
@@ -1,0 +1,12 @@
+package com.tuk.oriddle.global.result
+
+class ResultResponse private constructor(
+    val code: String,
+    val message: String,
+    val data: Any?
+) {
+    companion object {
+        fun of(resultCode: ResultCode, data: Any? = null): ResultResponse =
+            ResultResponse(resultCode.code, resultCode.message, data)
+    }
+}


### PR DESCRIPTION
## 📢 설명
API 공통 응답 객체인 ResultResponse와 에러 발생 시 catch하여 공통 에러 객체를 반환하도록 하는 에러 핸들러 구현

## ✅ 테스트 목록
- [ ] API 요청 시 공통 응답 객체에 담아서 오는지 확인
- [ ] 예외 발생 시 공통 예외 객체에 담아서 오는지 확인