### PR TITLE
[feat/#17] 예시용 퀴즈 생성 API 구현

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/quiz/controller/QuizController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quiz/controller/QuizController.kt
@@ -1,0 +1,23 @@
+package com.tuk.oriddle.domain.quiz.controller
+
+import com.tuk.oriddle.domain.quiz.dto.QuizCreateRequest
+import com.tuk.oriddle.domain.quiz.entity.Quiz
+import com.tuk.oriddle.domain.quiz.service.QuizService
+import com.tuk.oriddle.global.result.ResultCode
+import com.tuk.oriddle.global.result.ResultResponse
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/quiz")
+class QuizController(private val quizService: QuizService) {
+    // TODO: 추후 수정 필요 (예시용 API로 사용하기 위해 임시로 구현)
+    @PostMapping
+    fun createQuiz(
+        @RequestBody @Valid quizCreateRequest: QuizCreateRequest
+    ): ResponseEntity<ResultResponse> {
+        val createdQuiz: Quiz = quizService.createQuiz(quizCreateRequest)
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.QUIZ_CREATE_SUCCESS, createdQuiz))
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quiz/dto/QuizRequestDTO.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quiz/dto/QuizRequestDTO.kt
@@ -1,0 +1,11 @@
+package com.tuk.oriddle.domain.quiz.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class QuizCreateRequest(
+    @field:NotBlank
+    val title: String,
+    val description: String,
+    val imageUrl: String,
+    val makerId: Long
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quiz/exception/QuizNotFoundException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quiz/exception/QuizNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.tuk.oriddle.domain.quiz.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+class QuizNotFoundException: BusinessException(ErrorCode.QUIZ_NOT_FOUND)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quiz/repository/QuizRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quiz/repository/QuizRepository.kt
@@ -1,0 +1,8 @@
+package com.tuk.oriddle.domain.quiz.repository
+
+import com.tuk.oriddle.domain.quiz.entity.Quiz
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface QuizRepository : JpaRepository<Quiz, Long>

--- a/src/main/kotlin/com/tuk/oriddle/domain/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quiz/service/QuizService.kt
@@ -1,0 +1,25 @@
+package com.tuk.oriddle.domain.quiz.service
+
+import com.tuk.oriddle.domain.quiz.dto.QuizCreateRequest
+import com.tuk.oriddle.domain.quiz.entity.Quiz
+import com.tuk.oriddle.domain.quiz.exception.QuizNotFoundException
+import com.tuk.oriddle.domain.quiz.repository.QuizRepository
+import com.tuk.oriddle.domain.user.service.UserService
+import org.springframework.stereotype.Service
+
+@Service
+class QuizService(
+    private val quizRepository: QuizRepository,
+    private val userService: UserService
+) {
+    fun createQuiz(quizCreateRequest: QuizCreateRequest): Quiz {
+        val maker = userService.getUser(quizCreateRequest.makerId)
+        val createdQuiz = Quiz(
+            title = quizCreateRequest.title,
+            description = quizCreateRequest.description,
+            image = quizCreateRequest.imageUrl,
+            maker = maker
+        )
+        return quizRepository.save(createdQuiz)
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/exception/UserNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.tuk.oriddle.domain.user.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+class UserNotFoundException: BusinessException(ErrorCode.USER_NOT_FOUND)

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/repository/UserRepository.kt
@@ -1,0 +1,8 @@
+package com.tuk.oriddle.domain.user.repository
+
+import com.tuk.oriddle.domain.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long>

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -1,0 +1,13 @@
+package com.tuk.oriddle.domain.user.service
+
+import com.tuk.oriddle.domain.user.entity.User
+import com.tuk.oriddle.domain.user.exception.UserNotFoundException
+import com.tuk.oriddle.domain.user.repository.UserRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(private val userRepository: UserRepository) {
+    fun getUser(id: Long): User {
+        return userRepository.findById(id).orElseThrow { UserNotFoundException() }
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -5,5 +5,8 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
     // Global
     INTERNAL_SERVER_ERROR(500, "GL0001", "서버 오류"),
     INPUT_INVALID_VALUE(409, "GL0002", "잘못된 입력"),
+
+    // User
+    USER_NOT_FOUND(404, "US0001", "유저를 찾을 수 없습니다."),
     ;
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -8,5 +8,8 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
 
     // User
     USER_NOT_FOUND(404, "US0001", "유저를 찾을 수 없습니다."),
+
+    // Quiz
+    QUIZ_NOT_FOUND(404, "QZ0001", "퀴즈를 찾을 수 없습니다."),
     ;
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
@@ -2,5 +2,7 @@ package com.tuk.oriddle.global.result
 
 enum class ResultCode(val code: String, val message: String) {
     // 도메인 별로 나눠서 관리
+    // Quiz
+    QUIZ_CREATE_SUCCESS("QZ0001", "퀴즈 생성 성공"),
     ;
 }


### PR DESCRIPTION
## 📢 설명
앞으로의 API 구현에 참고할 예시용 퀴즈 생성 API 구현

## ✅ 테스트 목록
- [ ] 제목을 빈 문자열로 넣거나 다른 변수들을 Body에 넣지 않으면 예외 발생하는지 테스트
- [ ] 존재하지 않는 user의 ID를 넣었을 때 응답으로 에러코드 `US0001`이 오는지 테스트
- [ ] 정상적으로 API 호출 시 정상적으로 Quiz가 생성되는지 테스트