### PR TITLE
[feat/#13]: 퀴즈방 생성 시, 해당 유저가 생성된 퀴즈방에 참가되는 로직 추가 및 퀴즈방 참가 API 수정

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/repository/ParticipantRepository.kt
@@ -2,11 +2,7 @@ package com.tuk.oriddle.domain.participant.repository
 
 import com.tuk.oriddle.domain.participant.entity.Participant
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import java.util.*
 
 interface ParticipantRepository : JpaRepository<Participant, Long> {
-    fun findByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long): Optional<Participant>
-    @Query("SELECT COUNT(p) FROM Participant p WHERE p.quizRoom.id = :quizId")
-    fun countParticipantsByQuizId(quizId: Long): Int
+    fun existsByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long): Boolean
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/service/ParticipantQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/service/ParticipantQueryService.kt
@@ -1,22 +1,16 @@
 package com.tuk.oriddle.domain.participant.service
 
 import com.tuk.oriddle.domain.participant.entity.Participant
-import com.tuk.oriddle.domain.participant.exception.ParticipantNotFoundException
 import com.tuk.oriddle.domain.participant.repository.ParticipantRepository
 import org.springframework.stereotype.Service
 
 @Service
 class ParticipantQueryService(private val participantRepository: ParticipantRepository) {
-    fun findByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long): Participant {
-        return participantRepository.findByQuizRoomIdAndUserId(quizRoomId, userId)
-            .orElseThrow{ ParticipantNotFoundException() }
-    }
-
-    fun countParticipantsByQuizRoomId(quizRoomId: Long): Int {
-        return participantRepository.countParticipantsByQuizId(quizRoomId)
-    }
-
     fun save(participant: Participant) {
         participantRepository.save(participant)
+    }
+
+    fun isUserAlreadyParticipant(quizRoomId: Long, userId: Long): Boolean {
+        return participantRepository.existsByQuizRoomIdAndUserId(quizRoomId, userId)
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -24,8 +24,8 @@ class QuizRoomController(private val quizRoomService: QuizRoomService) {
         @AuthenticationPrincipal oauth2User: OAuth2User
     ): ResponseEntity<ResultResponse> {
         val userId = oauth2User.name.toLong()
-        val quizRoom: QuizRoomCreateResponse = quizRoomService.createQuizRoom(request, userId)
-        return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_CREATE_SUCCESS, quizRoom))
+        val response: QuizRoomCreateResponse = quizRoomService.createQuizRoom(request, userId)
+        return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_CREATE_SUCCESS, response))
     }
 
     @Secured("ROLE_USER")
@@ -35,7 +35,7 @@ class QuizRoomController(private val quizRoomService: QuizRoomService) {
         @AuthenticationPrincipal oauth2User: OAuth2User
     ): ResponseEntity<ResultResponse> {
         val userId = oauth2User.name.toLong()
-        val quizRoomJoin: QuizRoomJoinResponse = quizRoomService.joinQuizRoom(roomId, userId)
-        return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_JOIN_SUCCESS, quizRoomJoin))
+        val response: QuizRoomJoinResponse = quizRoomService.joinQuizRoom(roomId, userId)
+        return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_JOIN_SUCCESS, response))
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -21,9 +21,11 @@ import org.springframework.web.bind.annotation.RestController
 class QuizRoomController(private val quizRoomService: QuizRoomService) {
     @PostMapping
     fun createQuizRoom(
-        @Valid @RequestBody request: QuizRoomCreateRequest
+        @Valid @RequestBody request: QuizRoomCreateRequest,
+        @RequestParam(name =  "user-id")
+        userId: Long
     ): ResponseEntity<ResultResponse> {
-        val quizRoom: QuizRoomCreateResponse = quizRoomService.createQuizRoom(request)
+        val quizRoom: QuizRoomCreateResponse = quizRoomService.createQuizRoom(request, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_CREATE_SUCCESS, quizRoom))
     }
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -4,27 +4,26 @@ import com.tuk.oriddle.domain.quizroom.dto.request.QuizRoomCreateRequest
 import com.tuk.oriddle.domain.quizroom.dto.response.QuizRoomCreateResponse
 import com.tuk.oriddle.domain.quizroom.dto.response.QuizRoomJoinResponse
 import com.tuk.oriddle.domain.quizroom.service.QuizRoomService
-import com.tuk.oriddle.global.result.ResultCode.QUIZ_ROOM_JOIN_SUCCESS
 import com.tuk.oriddle.global.result.ResultCode.QUIZ_ROOM_CREATE_SUCCESS
+import com.tuk.oriddle.global.result.ResultCode.QUIZ_ROOM_JOIN_SUCCESS
 import com.tuk.oriddle.global.result.ResultResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.security.access.annotation.Secured
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/quiz-room")
 class QuizRoomController(private val quizRoomService: QuizRoomService) {
+    @Secured("ROLE_USER")
     @PostMapping
     fun createQuizRoom(
         @Valid @RequestBody request: QuizRoomCreateRequest,
-        @RequestParam(name =  "user-id")
-        userId: Long
+        @AuthenticationPrincipal oauth2User: OAuth2User
     ): ResponseEntity<ResultResponse> {
+        val userId = oauth2User.name.toLong()
         val quizRoom: QuizRoomCreateResponse = quizRoomService.createQuizRoom(request, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_CREATE_SUCCESS, quizRoom))
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -28,13 +28,13 @@ class QuizRoomController(private val quizRoomService: QuizRoomService) {
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_CREATE_SUCCESS, quizRoom))
     }
 
+    @Secured("ROLE_USER")
     @PostMapping("/{room-id}/join")
     fun joinQuizRoom(
-        @PathVariable(name = "room-id")
-        roomId: Long,
-        @RequestParam(name = "user-id")
-        userId: Long
+        @PathVariable(name = "room-id") roomId: Long,
+        @AuthenticationPrincipal oauth2User: OAuth2User
     ): ResponseEntity<ResultResponse> {
+        val userId = oauth2User.name.toLong()
         val quizRoomJoin: QuizRoomJoinResponse = quizRoomService.joinQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_JOIN_SUCCESS, quizRoomJoin))
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
@@ -11,8 +11,6 @@ data class QuizRoomCreateRequest(
     val title: String?,
     @field:NotNull(message = "maxParticipant는 비어 있을 수 없습니다.")
     val maxParticipant: Integer?,
-    @field:NotNull(message = "questionCount는 비어 있을 수 없습니다.")
-    val questionCount: Integer?
 ) {
     companion object {
         fun of(
@@ -23,8 +21,7 @@ data class QuizRoomCreateRequest(
                 QuizRoom(
                     quiz = quiz,
                     title = it.title!!,
-                    maxParticipant = it.maxParticipant!!,
-                    questionCount = it.questionCount!!
+                    maxParticipant = it.maxParticipant!!
                 )
             }
         }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
@@ -1,32 +1,15 @@
 package com.tuk.oriddle.domain.quizroom.dto.request
 
-import com.tuk.oriddle.domain.quiz.entity.Quiz
-import com.tuk.oriddle.domain.quizroom.entity.QuizRoom
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
 data class QuizRoomCreateRequest(
     val quizId: Long,
     @field:NotBlank(message = "title은 비어 있을 수 없습니다.")
-    val title: String?,
+    val title: String,
     @field:NotNull(message = "maxParticipant는 비어 있을 수 없습니다.")
-    val maxParticipant: Integer?,
-) {
-    companion object {
-        fun of(
-            quiz: Quiz,
-            quizRoomCreateRequest: QuizRoomCreateRequest
-        ): QuizRoom {
-            return quizRoomCreateRequest.let {
-                QuizRoom(
-                    quiz = quiz,
-                    title = it.title!!,
-                    maxParticipant = it.maxParticipant!!
-                )
-            }
-        }
-    }
-}
+    val maxParticipant: Int,
+)
 
 
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizRoom.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizRoom.kt
@@ -1,7 +1,6 @@
 package com.tuk.oriddle.domain.quizroom.entity
 
 import com.tuk.oriddle.domain.quiz.entity.Quiz
-import com.tuk.oriddle.domain.user.entity.User
 import com.tuk.oriddle.global.entity.BaseEntity
 import jakarta.persistence.*
 
@@ -9,7 +8,6 @@ import jakarta.persistence.*
 class QuizRoom(
     title: String,
     maxParticipant: Integer,
-    questionCount: Integer,
     quiz: Quiz
 ) : BaseEntity() {
     @Column(name = "title", nullable = false)
@@ -18,10 +16,6 @@ class QuizRoom(
 
     @Column(name = "max_participant", nullable = false)
     var maxParticipant: Integer = maxParticipant
-        private set
-
-    @Column(name = "question_count", nullable = false)
-    var questionCount: Integer = questionCount
         private set
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizRoom.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizRoom.kt
@@ -1,5 +1,6 @@
 package com.tuk.oriddle.domain.quizroom.entity
 
+import com.tuk.oriddle.domain.participant.entity.Participant
 import com.tuk.oriddle.domain.quiz.entity.Quiz
 import com.tuk.oriddle.global.entity.BaseEntity
 import jakarta.persistence.*
@@ -22,4 +23,10 @@ class QuizRoom(
     @JoinColumn(name = "quiz_id", nullable = false)
     var quiz: Quiz = quiz
         private set
+
+    @OneToMany(mappedBy = "quizRoom", fetch = FetchType.LAZY)
+    var participants: MutableList<Participant> = mutableListOf()
+        private set
+
+    fun isFull(): Boolean = participants.size >= maxParticipant
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizRoom.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizRoom.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.*
 @Entity
 class QuizRoom(
     title: String,
-    maxParticipant: Integer,
+    maxParticipant: Int,
     quiz: Quiz
 ) : BaseEntity() {
     @Column(name = "title", nullable = false)
@@ -15,7 +15,7 @@ class QuizRoom(
         private set
 
     @Column(name = "max_participant", nullable = false)
-    var maxParticipant: Integer = maxParticipant
+    var maxParticipant: Int = maxParticipant
         private set
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/QuizRoomAlreadyParticipantException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/QuizRoomAlreadyParticipantException.kt
@@ -1,0 +1,8 @@
+package com.tuk.oriddle.domain.quizroom.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+class QuizRoomAlreadyParticipantException : BusinessException {
+    constructor() : super(ErrorCode.QUIZ_ROOM_ALREADY_PARTICIPANT)
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -22,10 +22,14 @@ class QuizRoomService(
     private val userQueryService: UserQueryService,
     private val participantQueryService: ParticipantQueryService
 ) {
-    fun createQuizRoom(quizRoomCreateRequest: QuizRoomCreateRequest): QuizRoomCreateResponse {
+    fun createQuizRoom(quizRoomCreateRequest: QuizRoomCreateRequest, userId: Long): QuizRoomCreateResponse {
         val quiz: Quiz = quizQueryService.findById(quizRoomCreateRequest.quizId)
         val quizRoom: QuizRoom = QuizRoomCreateRequest.of(quiz, quizRoomCreateRequest)
+        val user: User = userQueryService.findById(userId)
+        checkQuizRoomJoinable(quizRoom) // 참가할 수 있는 상태인지 검증
+        val participant = Participant(quizRoom, user)
         quizRoomRepository.save(quizRoom)
+        participantQueryService.save(participant)
         return QuizRoomCreateResponse.of(quizRoom.id)
     }
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -29,7 +29,6 @@ class QuizRoomService(
     ): QuizRoomCreateResponse {
         val quiz: Quiz = quizQueryService.findById(request.quizId)
         val quizRoom = QuizRoom(request.title, request.maxParticipant, quiz)
-        checkJoinQuizRoom(quizRoom)
         val user: User = userQueryService.findById(userId)
         quizRoomRepository.save(quizRoom)
         val participant = Participant(quizRoom, user)

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -11,11 +11,11 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
 
     // Quiz (QR)
     QUIZ_ROOM_NOT_FOUND(400, "QR0001", "퀴즈방을 찾을 수 없음"),
-    QUIZ_ROOM_IS_FULL(400, "QR002", "퀴즈방이 꽉 차 있음"),
+    QUIZ_ROOM_IS_FULL(400, "QR0002", "퀴즈방이 꽉 차 있음"),
 
     // User (US)
-    USER_NOT_FOUND(400,"US001","유저를 찾을 수 없음"),
+    USER_NOT_FOUND(400,"US0001","유저를 찾을 수 없음"),
 
     // Participant (PC)
-    PARTICIPANT_NOT_FOUND(400,"PC001","참가자를 찾을 수 없음"),
+    PARTICIPANT_NOT_FOUND(400,"PC0001","참가자를 찾을 수 없음"),
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -18,4 +18,5 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
 
     // Participant (PC)
     PARTICIPANT_NOT_FOUND(400,"PC0001","참가자를 찾을 수 없음"),
+    QUIZ_ROOM_ALREADY_PARTICIPANT(400, "PC0002", "이미 퀴즈방에 참가중"),
 }


### PR DESCRIPTION
## 📢 설명
- 유저가 퀴즈방 생성 시, 해당 유저는 생성된 퀴즈방으로 참가하는 로직 추가
- poc 단계에서 필요 없는 question_count 제거
- 퀴즈방 생성 및 참가 시 세션에 있는 유저 정보를 이용하도록 수정
- 트랜잭션 적용
- 이미 참가중인 경우 예외를 반환하도록 수정
- 몇몇 부분 리팩토링(메서드명 변경, 변수명 변경 등)

## ✅ 테스트 목록
- [x] 퀴즈방 생성 시, 해당 유저가 퀴즈방에 참가자로 추가되는지
- [x] 퀴즈방 참가 시, 해당 유저가 퀴즈방에 참가자로 추가되는지
- [x] 퀴즈방 참가 시, 퀴즈방이 꽉 찼으면 예외가 발생하는지
- [x] 퀴즈방 참가 시, 이미 참가중이면 예외가 발생하는지
- [x] 퀴즈방 참가, 생성 시 로그인이 안되어 있으면 401에러가 발생하는지
- [x] 트랜잭션 적용이 잘 되었는지(중간에 예외를 발생시키고, 롤백이 되는지 확인)