### PR TITLE
[feat/#23] 구글 소셜 로그인 구현 및 로그인 사용자 정보 조회 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,18 +31,24 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-websocket")
+	implementation("org.springframework.boot:spring-boot-starter-jdbc")
+	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+	// security
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.security:spring-security-test")
 
 	// Swagger
 	implementation("org.springdoc:springdoc-openapi:2.3.0")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
 	runtimeOnly("com.h2database:h2")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("org.springframework.boot:spring-boot-starter-jdbc")
 	runtimeOnly("mysql:mysql-connector-java:8.0.33")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.springframework.security:spring-security-test")
 }
 
 jib {

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
@@ -1,0 +1,26 @@
+package com.tuk.oriddle.domain.user.controller
+
+import com.tuk.oriddle.domain.user.dto.response.UserInfoResponse
+import com.tuk.oriddle.domain.user.service.UserQueryService
+import com.tuk.oriddle.global.result.ResultCode
+import com.tuk.oriddle.global.result.ResultResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.annotation.Secured
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user")
+class UserController(private val userQueryService: UserQueryService) {
+    @Secured("ROLE_USER")
+    @GetMapping("/info")
+    fun getLoginUserInfo(@AuthenticationPrincipal oauth2User: OAuth2User): ResponseEntity<ResultResponse> {
+        val userId = oauth2User.attributes["userId"] as Long
+        val user = userQueryService.findById(userId)
+        val userInfoResponse = UserInfoResponse.of(user)
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_GET_SUCCESS, userInfoResponse))
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/dto/response/UserInfoResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/dto/response/UserInfoResponse.kt
@@ -1,0 +1,17 @@
+package com.tuk.oriddle.domain.user.dto.response
+
+import com.tuk.oriddle.domain.user.entity.User
+
+data class UserInfoResponse(
+    val userId: Long, val email: String, val nickname: String
+) {
+    companion object {
+        fun of(
+            user: User
+        ): UserInfoResponse {
+            return UserInfoResponse(
+                user.id, user.email, user.nickname
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/entity/User.kt
@@ -1,20 +1,16 @@
 package com.tuk.oriddle.domain.user.entity
 
 import com.tuk.oriddle.global.entity.BaseEntity
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
 
 @Entity
 class User(
     email: String,
-    password: String,
     nickname: String
 ) : BaseEntity() {
     @Column(name = "email", nullable = false)
     var email: String = email
-        private set
-
-    @Column(name = "password", nullable = false)
-    var password: String = password
         private set
 
     @Column(name = "nickname", nullable = false)

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/repository/UserRepository.kt
@@ -4,4 +4,5 @@ import com.tuk.oriddle.domain.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
@@ -11,4 +11,10 @@ class UserQueryService(private val userRepository: UserRepository) {
         return userRepository.findById(userId)
             .orElseThrow { UserNotFoundException() }
     }
+
+    fun findOrCreateUserByEmail(email: String): User {
+        // TODO: nickname 자동 생성 로직 추가하기
+        return userRepository.findByEmail(email)?.let { it }
+            ?: userRepository.save(User(email = email, nickname = "기본 이름"))
+    }
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/config/SecurityConfig.kt
@@ -1,0 +1,33 @@
+package com.tuk.oriddle.global.config
+
+import com.tuk.oriddle.global.oauth.CustomOAuth2UserService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.HttpStatusEntryPoint
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+class SecurityConfig(
+    private val customOAuth2UserService: CustomOAuth2UserService
+) {
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http.exceptionHandling { exceptions ->
+            exceptions.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+        }.logout { logout ->
+            logout.logoutSuccessUrl("/")
+        }.oauth2Login { oauth2Login ->
+            oauth2Login
+                .userInfoEndpoint { userInfoEndpoint ->
+                    userInfoEndpoint.userService(customOAuth2UserService)
+                }
+        }
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -4,6 +4,7 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
     // Global (GL)
     INTERNAL_SERVER_ERROR(500, "GL0001", "서버 오류"),
     INPUT_INVALID_VALUE(409, "GL0002", "잘못된 입력"),
+    ACCESS_DENIED(401, "GL0003", "로그인이 필요합니다."),
 
     // Quiz (QZ)
     QUIZ_NOT_FOUND(400, "QZ0001", "퀴즈를 찾을 수 없음"),

--- a/src/main/kotlin/com/tuk/oriddle/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/GlobalExceptionHandler.kt
@@ -1,9 +1,11 @@
 package com.tuk.oriddle.global.error
 
 import com.tuk.oriddle.global.error.exception.BusinessException
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -25,6 +27,16 @@ class GlobalExceptionHandler {
         val response = ErrorResponse.of(errorCode)
         log.warn(e.message)
         return ResponseEntity.status(errorCode.status).body(response)
+    }
+
+    @ExceptionHandler(AccessDeniedException::class)
+    protected fun handleAccessDeniedException(
+        e: AccessDeniedException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse?>? {
+        log.warn("${e.message}: [${request.method}] ${request.requestURI}")
+        val response = ErrorResponse.of(ErrorCode.ACCESS_DENIED)
+        return ResponseEntity(response, HttpStatus.UNAUTHORIZED)
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)

--- a/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomOAuth2UserService.kt
@@ -1,0 +1,28 @@
+package com.tuk.oriddle.global.oauth
+
+import com.tuk.oriddle.domain.user.service.UserQueryService
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+
+@Service
+class CustomOAuth2UserService(private val userQueryService: UserQueryService) : DefaultOAuth2UserService() {
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val oauth2User = super.loadUser(userRequest)
+
+        val email = oauth2User.attributes["email"] as String
+        val user = userQueryService.findOrCreateUserByEmail(email)
+
+        val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
+        val attributes = mapOf("userId" to user.id)
+
+        return DefaultOAuth2User(
+            authorities,
+            attributes,
+            "userId"
+        )
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
@@ -7,5 +7,8 @@ enum class ResultCode(val code: String, val message: String) {
 
     // QuizRoom (QR)
     QUIZ_ROOM_CREATE_SUCCESS("QR0001", "퀴즈방 생성 성공"),
-    QUIZ_ROOM_JOIN_SUCCESS("QR0002", "퀴즈방 참여 성공")
+    QUIZ_ROOM_JOIN_SUCCESS("QR0002", "퀴즈방 참여 성공"),
+
+    // User (US)
+    USER_GET_SUCCESS("US0001", "유저 정보 조회 성공"),
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles.include:
     - db
+    - oauth
   jpa:
     database: mysql
     show-sql: true


### PR DESCRIPTION
## 📢 설명
구글 소셜 로그인 구현 및 로그인 사용자 정보 조회 API 구현

## ✅ 테스트 목록
- [x] 테스트 유저 등록 or 직접 구글 프로젝트 생성
- [x] application-oauth.yml 추가(노션 "로그인 관련 설정 정리" 문서 확인)
- [x] 서버 실행하여 /api/v1/user/info 호출 시 401에러 발생하는지 확인
- [x] http://localhost:8080/oauth2/authorization/google로 이동하여 로그인 진행 확인
- [x] 다시 /api/v1/user/info 호출하여 정상적으로 응답이 나오는지 확인