### PR TITLE
[feat/#30] 퀴즈방 참가, 퇴장 시 클라이언트에게 메시지 보내는 기능 구현

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/JoinQuizRoomMessage.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/JoinQuizRoomMessage.kt
@@ -1,0 +1,7 @@
+package com.tuk.oriddle.domain.quizroom.dto.message
+
+data class JoinQuizRoomMessage(
+    val userId: Long,
+    val nickname: String,
+    val position: Int
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/LeaveQuizRoomMessage.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/LeaveQuizRoomMessage.kt
@@ -1,0 +1,5 @@
+package com.tuk.oriddle.domain.quizroom.dto.message
+
+data class LeaveQuizRoomMessage(
+    val userId: Long
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
@@ -19,7 +19,7 @@ class QuizRoomMessageService(
     fun sendQuizRoomLeaveMessage(quizRoomId: Long, userId: Long) {
         messagingTemplate.convertAndSend(
             "/topic/quiz-room/$quizRoomId/leave",
-            LeaveQuizRoomMessage(quizRoomId)
+            LeaveQuizRoomMessage(userId)
         )
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
@@ -1,0 +1,25 @@
+package com.tuk.oriddle.domain.quizroom.service
+
+import com.tuk.oriddle.domain.quizroom.dto.message.JoinQuizRoomMessage
+import com.tuk.oriddle.domain.quizroom.dto.message.LeaveQuizRoomMessage
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class QuizRoomMessageService(
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+    fun sendQuizRoomJoinMessage(quizRoomId: Long, userId: Long, nickname: String, position: Int) {
+        messagingTemplate.convertAndSend(
+            "/topic/quiz-room/$quizRoomId/join",
+            JoinQuizRoomMessage(userId, nickname, position)
+        )
+    }
+
+    fun sendQuizRoomLeaveMessage(quizRoomId: Long, userId: Long) {
+        messagingTemplate.convertAndSend(
+            "/topic/quiz-room/$quizRoomId/leave",
+            LeaveQuizRoomMessage(quizRoomId)
+        )
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/config/WebSocketConfig.kt
@@ -1,0 +1,20 @@
+package com.tuk.oriddle.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/ws").setAllowedOrigins("*")
+    }
+
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.setApplicationDestinationPrefixes("/app")
+        registry.enableSimpleBroker("/topic")
+    }
+}


### PR DESCRIPTION
## 📢 설명
- 퀴즈방 참가, 퇴장 시 클라이언트에게 WebSocket 메시지를 보내는 기능 구현

## ✅ 테스트 목록
- [x] 웹 소켓 연결 후 사용자가 참가, 퇴장 했을 때 메시지가 오는지 확인

## 테스트 방법
1. postman 설치 및 new 버튼을 눌러서 웹 소켓 request 생성

    <img width="636" alt="image" src="https://github.com/Team-Oriddle/oriddle-backend/assets/108508730/5ab56c96-cc54-4ba6-b771-316562661191">

2. Enter URL에 ws://localhost:8080/ws 입력

3. 서버 실행 후 PostMan에서 Connect버튼 클릭

4. 아래 메시지 입력 후 Send 버튼 클릭 후 응답 오는지 확인
    
    ```
    CONNECT
    accept-version:1.1,1.0
    heart-beat:10000,10000
    
    {{NULL_CHAR}}
    ```
    
    <img width="444" alt="image" src="https://github.com/Team-Oriddle/oriddle-backend/assets/108508730/4529c7c0-73a9-49f0-a7cd-c7a6305410e8">

5. 로그인 후 퀴즈방 생성 하기
    
    
6. 아래 메시지들 입력 후 각각 Send 버튼 클릭(8은 본인의 quiz-room-id로 변경)
    
    ```
    SUBSCRIBE
    id:sub-1
    destination:/topic/quiz-room/8/join
    
    {{NULL_CHAR}}
    ```
    
    ```
    SUBSCRIBE
    id:sub-2
    destination:/topic/quiz-room/8/leave
    
    {{NULL_CHAR}}
    ```
    
7. 다른 계정으로 로그인 뒤 퀴즈방 참가 API 호출한 뒤 postman에서 메시지 왔는지 확인
    
    <img width="580" alt="image" src="https://github.com/Team-Oriddle/oriddle-backend/assets/108508730/efbf4fe7-6fe5-426c-93e1-68a622ba06cb">
    
8. 퀴즈방 퇴장 API 호출한 뒤 postman에서 메시지 왔는지 확인
    
    <img width="586" alt="image" src="https://github.com/Team-Oriddle/oriddle-backend/assets/108508730/b1d83041-ea2c-4368-94e3-5283d6464ab8">

