### PR TITLE
[feat/#32] 퀴즈방 시작 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
 	// security
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
     networks:
       - default
 
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+
 networks:
   default:
     driver: bridge

--- a/src/main/kotlin/com/tuk/oriddle/OriddleApplication.kt
+++ b/src/main/kotlin/com/tuk/oriddle/OriddleApplication.kt
@@ -3,9 +3,11 @@ package com.tuk.oriddle
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class OriddleApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/tuk/oriddle/domain/question/entity/Question.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/question/entity/Question.kt
@@ -1,5 +1,6 @@
 package com.tuk.oriddle.domain.question.entity
 
+import com.tuk.oriddle.domain.answer.entity.Answer
 import com.tuk.oriddle.domain.quiz.entity.Quiz
 import com.tuk.oriddle.global.entity.BaseEntity
 import jakarta.persistence.*
@@ -49,4 +50,15 @@ class Question(
     @JoinColumn(name = "quiz_id", nullable = false)
     var quiz: Quiz = quiz
         private set
+
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    var answers: MutableList<Answer> = mutableListOf()
+        private set
+
+    fun getMainAnswerContent(): String? {
+        for (answer in answers) {
+            if (answer.isMainAnswer) return answer.content
+        }
+        return null
+    }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/question/entity/Question.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/question/entity/Question.kt
@@ -61,4 +61,8 @@ class Question(
         }
         return null
     }
+
+    fun getAnswerSet(): MutableSet<String> {
+        return answers.map { it.content }.toMutableSet()
+    }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/question/repository/QuestionRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/question/repository/QuestionRepository.kt
@@ -1,7 +1,6 @@
 package com.tuk.oriddle.domain.question.repository
 
 import com.tuk.oriddle.domain.question.entity.Question
-import com.tuk.oriddle.domain.quiz.entity.Quiz
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface QuestionRepository : JpaRepository<Question, Long> {

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -58,4 +58,15 @@ class QuizRoomController(private val quizRoomService: QuizRoomService) {
         quizRoomService.leaveQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_LEAVE_SUCCESS))
     }
+
+    @Secured("ROLE_USER")
+    @PostMapping("/{room-id}/start")
+    fun startQuizRoom(
+        @PathVariable(name = "room-id") roomId: Long,
+        @AuthenticationPrincipal oauth2User: OAuth2User
+    ): ResponseEntity<ResultResponse> {
+        // TODO: 방장만 시작할 수 있도록 변경
+        quizRoomService.startQuizRoom(roomId)
+        return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_START_SUCCESS))
+    }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/QuestionMessage.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/QuestionMessage.kt
@@ -1,0 +1,29 @@
+package com.tuk.oriddle.domain.quizroom.dto.message
+
+import com.tuk.oriddle.domain.question.entity.QuestionSourceType
+import com.tuk.oriddle.domain.question.entity.QuestionType
+import com.tuk.oriddle.domain.quizroom.dto.redis.QuestionRedisDto
+
+data class QuestionMessage(
+    val number: Long,
+    val description: String,
+    val type: QuestionType,
+    val sourceType: QuestionSourceType,
+    val source: String?,
+    val score: Int,
+    val timeLimit: Int,
+) {
+    companion object {
+        fun of(questionRedisDto: QuestionRedisDto): QuestionMessage {
+            return QuestionMessage(
+                questionRedisDto.number,
+                questionRedisDto.description,
+                questionRedisDto.type,
+                questionRedisDto.sourceType,
+                questionRedisDto.source,
+                questionRedisDto.score,
+                questionRedisDto.timeLimit
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/StartQuizRoomMessage.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/StartQuizRoomMessage.kt
@@ -1,0 +1,5 @@
+package com.tuk.oriddle.domain.quizroom.dto.message
+
+data class StartQuizRoomMessage(
+    val waitTime: Long
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/redis/QuestionRedisDto.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/redis/QuestionRedisDto.kt
@@ -1,0 +1,33 @@
+package com.tuk.oriddle.domain.quizroom.dto.redis
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.tuk.oriddle.domain.question.entity.Question
+import com.tuk.oriddle.domain.question.entity.QuestionSourceType
+import com.tuk.oriddle.domain.question.entity.QuestionType
+
+data class QuestionRedisDto @JsonCreator constructor(
+    @JsonProperty("number") val number: Long,
+    @JsonProperty("description") val description: String,
+    @JsonProperty("type") val type: QuestionType,
+    @JsonProperty("sourceType") val sourceType: QuestionSourceType,
+    @JsonProperty("source") val source: String?,
+    @JsonProperty("score") val score: Int,
+    @JsonProperty("timeLimit") val timeLimit: Int,
+    @JsonProperty("mainAnswer") val mainAnswer: String?
+) {
+    companion object {
+        fun of(question: Question): QuestionRedisDto {
+            return QuestionRedisDto(
+                question.number,
+                question.description,
+                question.type,
+                question.sourceType,
+                question.source,
+                question.score,
+                question.timeLimit,
+                question.getMainAnswerContent()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/redis/QuizStatusRedisDto.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/redis/QuizStatusRedisDto.kt
@@ -1,0 +1,12 @@
+package com.tuk.oriddle.domain.quizroom.dto.redis
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.tuk.oriddle.domain.quizroom.entity.QuizProgressStatus
+
+data class QuizStatusRedisDto @JsonCreator constructor(
+    @JsonProperty("quizId") val quizId: Long,
+    @JsonProperty("questionCount") val questionCount: Long,
+    @JsonProperty("status") val status: QuizProgressStatus = QuizProgressStatus.WAIT,
+    @JsonProperty("currentQuestionNumber") val currentQuestionNumber: Long = 1
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/redis/UserRedisDto.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/redis/UserRedisDto.kt
@@ -1,0 +1,10 @@
+package com.tuk.oriddle.domain.quizroom.dto.redis
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class UserRedisDto @JsonCreator constructor(
+    @JsonProperty("userId") val userId: Long,
+    @JsonProperty("position") val position: Int,
+    @JsonProperty("score") val score: Int = 0
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
@@ -1,5 +1,7 @@
 package com.tuk.oriddle.domain.quizroom.dto.request
 
+import com.tuk.oriddle.domain.quiz.entity.Quiz
+import com.tuk.oriddle.domain.quizroom.entity.QuizRoom
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
@@ -9,7 +11,11 @@ data class QuizRoomCreateRequest(
     val title: String,
     @field:NotNull(message = "maxParticipant는 비어 있을 수 없습니다.")
     val maxParticipant: Int,
-)
+) {
+    fun toEntity(quiz: Quiz): QuizRoom {
+        return QuizRoom(this.title, this.maxParticipant, quiz)
+    }
+}
 
 
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizProgressStatus.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/entity/QuizProgressStatus.kt
@@ -1,0 +1,5 @@
+package com.tuk.oriddle.domain.quizroom.entity
+
+enum class QuizProgressStatus {
+    WAIT, PROGRESS, FINISH
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/QuestionNotFoundInRedisException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/QuestionNotFoundInRedisException.kt
@@ -1,0 +1,9 @@
+package com.tuk.oriddle.domain.quizroom.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+// TODO: 패키지 바꾸기
+class QuestionNotFoundInRedisException : BusinessException {
+    constructor() : super(ErrorCode.QUESTION_NOT_FOUND_IN_REDIS)
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/QuizStatusNotFoundInRedisException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/QuizStatusNotFoundInRedisException.kt
@@ -1,0 +1,9 @@
+package com.tuk.oriddle.domain.quizroom.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+// TODO: 패키지 바꾸기
+class QuizStatusNotFoundInRedisException : BusinessException {
+    constructor() : super(ErrorCode.QUIZ_STATUS_NOT_FOUND_IN_REDIS)
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/scheduler/QuizRoomScheduler.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/scheduler/QuizRoomScheduler.kt
@@ -1,0 +1,34 @@
+package com.tuk.oriddle.domain.quizroom.scheduler
+
+import com.tuk.oriddle.domain.quizroom.dto.message.QuestionMessage
+import com.tuk.oriddle.domain.quizroom.service.QuizRoomMessageService
+import com.tuk.oriddle.domain.quizroom.service.QuizRoomRedisService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.stereotype.Component
+
+@Component
+@EnableAsync
+class QuizRoomScheduler(
+    private val quizRoomMessageService: QuizRoomMessageService,
+    private val quizRoomRedisService: QuizRoomRedisService,
+    @Value("\${config.quiz-room.start-wait-time}")
+    private val startWaitTime: Long
+) {
+    @Async
+    fun scheduleQuestionPublish(quizRoomId: Long) {
+        Thread.sleep(secToMilliSec(startWaitTime))
+        val quizStatusRedisDto = quizRoomRedisService.getQuizStatus(quizRoomId)
+        val quizId = quizStatusRedisDto.quizId
+        val currentQuestionNumber = quizStatusRedisDto.currentQuestionNumber
+        val currentQuestionRedisDto = quizRoomRedisService.getQuestion(quizId, currentQuestionNumber)
+        val questionMessage = QuestionMessage.of(currentQuestionRedisDto)
+        quizRoomMessageService.sendQuestionMessage(quizRoomId, questionMessage)
+        // TODO: 문제 제한시간이 다 되면 메시지를 발송하는 기능 구현하기
+    }
+
+    private fun secToMilliSec(sec: Long): Long {
+        return sec * 1000
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
@@ -3,12 +3,16 @@ package com.tuk.oriddle.domain.quizroom.service
 import com.tuk.oriddle.domain.quizroom.dto.message.JoinQuizRoomMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.LeaveQuizRoomMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.QuestionMessage
+import com.tuk.oriddle.domain.quizroom.dto.message.StartQuizRoomMessage
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 
 @Service
 class QuizRoomMessageService(
-    private val messagingTemplate: SimpMessagingTemplate
+    private val messagingTemplate: SimpMessagingTemplate,
+    @Value("\${config.quiz-room.start-wait-time}")
+    private val startWaitTime: Long
 ) {
     fun sendQuizRoomJoinMessage(quizRoomId: Long, userId: Long, nickname: String, position: Int) {
         messagingTemplate.convertAndSend(
@@ -21,6 +25,13 @@ class QuizRoomMessageService(
         messagingTemplate.convertAndSend(
             "/topic/quiz-room/$quizRoomId/leave",
             LeaveQuizRoomMessage(userId)
+        )
+    }
+
+    fun sendQuizRoomStartMessage(quizRoomId: Long) {
+        messagingTemplate.convertAndSend(
+            "/topic/quiz-room/$quizRoomId/start",
+            StartQuizRoomMessage(startWaitTime)
         )
     }
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
@@ -2,6 +2,7 @@ package com.tuk.oriddle.domain.quizroom.service
 
 import com.tuk.oriddle.domain.quizroom.dto.message.JoinQuizRoomMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.LeaveQuizRoomMessage
+import com.tuk.oriddle.domain.quizroom.dto.message.QuestionMessage
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 
@@ -21,5 +22,9 @@ class QuizRoomMessageService(
             "/topic/quiz-room/$quizRoomId/leave",
             LeaveQuizRoomMessage(userId)
         )
+    }
+
+    fun sendQuestionMessage(quizRoomId: Long, questionMessage: QuestionMessage) {
+        messagingTemplate.convertAndSend("/topic/quiz-room/$quizRoomId/question", questionMessage)
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomQueryService.kt
@@ -1,0 +1,13 @@
+package com.tuk.oriddle.domain.quizroom.service
+
+import com.tuk.oriddle.domain.quizroom.entity.QuizRoom
+import com.tuk.oriddle.domain.quizroom.exception.QuizRoomNotFoundException
+import com.tuk.oriddle.domain.quizroom.repository.QuizRoomRepository
+import org.springframework.stereotype.Service
+
+@Service
+class QuizRoomQueryService(private val quizRoomRepository: QuizRoomRepository) {
+    fun findById(quizRoomId: Long): QuizRoom {
+        return quizRoomRepository.findById(quizRoomId).orElseThrow { QuizRoomNotFoundException() }
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomRedisService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomRedisService.kt
@@ -6,6 +6,7 @@ import com.tuk.oriddle.domain.question.entity.Question
 import com.tuk.oriddle.domain.quizroom.dto.redis.QuestionRedisDto
 import com.tuk.oriddle.domain.quizroom.dto.redis.QuizStatusRedisDto
 import com.tuk.oriddle.domain.quizroom.dto.redis.UserRedisDto
+import com.tuk.oriddle.domain.quizroom.exception.QuizStatusNotFoundInRedisException
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 
@@ -13,11 +14,19 @@ import org.springframework.stereotype.Service
 @Service
 class QuizRoomRedisService(
     private val redisTemplate: RedisTemplate<String, Any>,
+    private val objectMapper: ObjectMapper
 ) {
     fun saveQuizStatus(quizRoomId: Long, quizId: Long, questionCount: Long) {
         val key = "qr:$quizRoomId:status"
         val status = QuizStatusRedisDto(quizId, questionCount)
         redisTemplate.opsForValue().set(key, status)
+    }
+
+    fun getQuizStatus(quizRoomId: Long): QuizStatusRedisDto {
+        val key = "qr:$quizRoomId:status"
+        val value =
+            redisTemplate.opsForValue().get(key) ?: throw QuizStatusNotFoundInRedisException()
+        return objectMapper.convertValue(value, QuizStatusRedisDto::class.java)
     }
 
     fun saveQuestionsAndAnswers(quizRoomId: Long, questions: MutableList<Question>) {

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomRedisService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomRedisService.kt
@@ -1,0 +1,52 @@
+package com.tuk.oriddle.domain.quizroom.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.tuk.oriddle.domain.participant.entity.Participant
+import com.tuk.oriddle.domain.question.entity.Question
+import com.tuk.oriddle.domain.quizroom.dto.redis.QuestionRedisDto
+import com.tuk.oriddle.domain.quizroom.dto.redis.QuizStatusRedisDto
+import com.tuk.oriddle.domain.quizroom.dto.redis.UserRedisDto
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+// TODO: Redis Repository 계층을 쓰도록 리팩토링
+@Service
+class QuizRoomRedisService(
+    private val redisTemplate: RedisTemplate<String, Any>,
+) {
+    fun saveQuizStatus(quizRoomId: Long, quizId: Long, questionCount: Long) {
+        val key = "qr:$quizRoomId:status"
+        val status = QuizStatusRedisDto(quizId, questionCount)
+        redisTemplate.opsForValue().set(key, status)
+    }
+
+    fun saveQuestionsAndAnswers(quizRoomId: Long, questions: MutableList<Question>) {
+        questions.map {
+            saveQuestion(quizRoomId, it.number, it)
+            saveAnswer(quizRoomId, it.number, it.getAnswerSet())
+        }
+    }
+
+    private fun saveQuestion(quizRoomId: Long, number: Long, question: Question) {
+        val key = "qr:$quizRoomId:question:$number"
+        val questionRedisDto = QuestionRedisDto.of(question)
+        redisTemplate.opsForValue().set(key, questionRedisDto)
+    }
+
+    private fun saveAnswer(quizRoomId: Long, number: Long, answers: MutableSet<String>) {
+        val key = "qr:$quizRoomId:answer:$number"
+        redisTemplate.opsForValue().set(key, answers)
+    }
+
+    fun saveQuizParticipants(quizRoomId: Long, participants: MutableList<Participant>) {
+        val key = "qr:$quizRoomId:users"
+        val participantInfos = makeParticipantInfosByParticipants(participants)
+        redisTemplate.opsForValue().set(key, participantInfos)
+    }
+
+    private fun makeParticipantInfosByParticipants(participants: MutableList<Participant>): MutableList<UserRedisDto> {
+        return participants.map {
+            UserRedisDto(it.user.id, it.position)
+        } as MutableList<UserRedisDto>
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomRedisService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomRedisService.kt
@@ -6,6 +6,7 @@ import com.tuk.oriddle.domain.question.entity.Question
 import com.tuk.oriddle.domain.quizroom.dto.redis.QuestionRedisDto
 import com.tuk.oriddle.domain.quizroom.dto.redis.QuizStatusRedisDto
 import com.tuk.oriddle.domain.quizroom.dto.redis.UserRedisDto
+import com.tuk.oriddle.domain.quizroom.exception.QuestionNotFoundInRedisException
 import com.tuk.oriddle.domain.quizroom.exception.QuizStatusNotFoundInRedisException
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
@@ -45,6 +46,12 @@ class QuizRoomRedisService(
     private fun saveAnswer(quizRoomId: Long, number: Long, answers: MutableSet<String>) {
         val key = "qr:$quizRoomId:answer:$number"
         redisTemplate.opsForValue().set(key, answers)
+    }
+
+    fun getQuestion(quizRoomId: Long, number: Long): QuestionRedisDto {
+        val key = "qr:$quizRoomId:question:$number"
+        val value = redisTemplate.opsForValue().get(key) ?: throw QuestionNotFoundInRedisException()
+        return objectMapper.convertValue(value, QuestionRedisDto::class.java)
     }
 
     fun saveQuizParticipants(quizRoomId: Long, participants: MutableList<Participant>) {

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -43,7 +43,7 @@ class QuizRoomService(
         request: QuizRoomCreateRequest, userId: Long
     ): QuizRoomCreateResponse {
         val quiz: Quiz = quizQueryService.findById(request.quizId)
-        val quizRoom = QuizRoom(request.title, request.maxParticipant, quiz)
+        val quizRoom = request.toEntity(quiz)
         val user: User = userQueryService.findById(userId)
         quizRoomRepository.save(quizRoom)
         val participant = Participant(quizRoom, user)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -26,7 +26,8 @@ class QuizRoomService(
     private val quizQueryService: QuizQueryService,
     private val userQueryService: UserQueryService,
     private val participantQueryService: ParticipantQueryService,
-    private val quizRoomMessageService: QuizRoomMessageService
+    private val quizRoomMessageService: QuizRoomMessageService,
+    private val quizRoomQueryService: QuizRoomQueryService
 ) {
     fun getQuizRoomInfo(quizRoomId: Long): QuizRoomInfoGetResponse {
         val quizRoom: QuizRoom = quizRoomRepository.findById(quizRoomId).orElseThrow { QuizRoomNotFoundException() }
@@ -60,8 +61,7 @@ class QuizRoomService(
     @Transactional
     fun joinQuizRoom(quizRoomId: Long, userId: Long): QuizRoomJoinResponse {
         // TODO: 쿼리 최적화 필요
-        val quizRoom: QuizRoom =
-            quizRoomRepository.findById(quizRoomId).orElseThrow { QuizRoomNotFoundException() }
+        val quizRoom = quizRoomQueryService.findById(quizRoomId)
         val user: User = userQueryService.findById(userId)
         checkJoinQuizRoom(quizRoom, user)
         val participant = Participant(quizRoom, user)

--- a/src/main/kotlin/com/tuk/oriddle/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/config/RedisConfig.kt
@@ -1,0 +1,23 @@
+package com.tuk.oriddle.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+    @Bean
+    fun redisTemplate(lettuceConnectionFactory: LettuceConnectionFactory): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
+        template.connectionFactory = lettuceConnectionFactory
+        val objectMapper = ObjectMapper().apply { registerKotlinModule() }
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
+        return template
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -9,9 +9,10 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
     // Quiz (QZ)
     QUIZ_NOT_FOUND(400, "QZ0001", "퀴즈를 찾을 수 없음"),
 
-    // Quiz (QR)
+    // QuizRoom (QR)
     QUIZ_ROOM_NOT_FOUND(400, "QR0001", "퀴즈방을 찾을 수 없음"),
     QUIZ_ROOM_IS_FULL(400, "QR0002", "퀴즈방이 꽉 차 있음"),
+    QUIZ_STATUS_NOT_FOUND_IN_REDIS(400, "QR0003", "퀴즈 진행 상태가 Redis에 없음"),
 
     // User (US)
     USER_NOT_FOUND(400,"US0001","유저를 찾을 수 없음"),

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -15,10 +15,13 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
     QUIZ_STATUS_NOT_FOUND_IN_REDIS(400, "QR0003", "퀴즈 진행 상태가 Redis에 없음"),
 
     // User (US)
-    USER_NOT_FOUND(400,"US0001","유저를 찾을 수 없음"),
+    USER_NOT_FOUND(400, "US0001", "유저를 찾을 수 없음"),
 
     // Participant (PC)
-    PARTICIPANT_NOT_FOUND(400,"PC0001","참가자를 찾을 수 없음"),
+    PARTICIPANT_NOT_FOUND(400, "PC0001", "참가자를 찾을 수 없음"),
     QUIZ_ROOM_ALREADY_PARTICIPANT(400, "PC0002", "이미 퀴즈방에 참가중"),
     USER_NOT_IN_QUIZ_ROOM(400, "PC0003", "사용자가 퀴즈방에 없음"),
+
+    // Question (QS)
+    QUESTION_NOT_FOUND_IN_REDIS(400, "QU0001", "질문이 Redis에 없음"),
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
@@ -10,6 +10,7 @@ enum class ResultCode(val code: String, val message: String) {
     QUIZ_ROOM_JOIN_SUCCESS("QR0002", "퀴즈방 참여 성공"),
     QUIZ_ROOM_LEAVE_SUCCESS("QR0003", "퀴즈방 퇴장 성공"),
     QUIZ_ROOM_GET_INFO_SUCCESS("QR0004","퀴즈방 정보 조회 성공"),
+    QUIZ_ROOM_START_SUCCESS("QR0005", "퀴즈 시작 성공"),
 
     // User (US)
     USER_GET_SUCCESS("US0001", "유저 정보 조회 성공"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,7 @@ springdoc:
 
 frontend:
   base-url: http://localhost:3000
+
+config:
+  quiz-room:
+    start-wait-time: 5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
     generate-ddl: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 springdoc:
   packages-to-scan: com.tuk.oriddle


### PR DESCRIPTION
## 📢 설명
- 퀴즈방 시작 API 구현
- Redis 설정 진행(Docker 세팅, Config 클래스, application.yml)
- 퀴즈 진행에 필요한 정보들을 조회해서 Redis에 저장하는 기능 구현
- 퀴즈 시작 메시지를 보내는 기능 구현
- 스케줄러를 이용하여 5초 뒤에 문제 공개 메시지를 보내는 기능 구현

## ✅ 테스트 목록
- [x] docker-compose로 redis 실행되는지 확인
- [x] 테스트를 위한 데이터 준비(유저, 퀴즈, 문제, 정답, 퀴즈방 생성)
- [x] 생성한 퀴즈방에 대해 시작 토픽과 문제 토픽 구독하기
- [x] 퀴즈 시작 API 호출 시 퀴즈 시작 메시지와, 5초 뒤에 문제 공개 메시지가 오는지 확인

테스트 진행 중 의문점이나 질문 있으면 주세요!