### PR TITLE
[feat/#38] 닉네임 수정 API 및 로그인 시, 랜덤 닉네임 부여 구현

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
@@ -1,20 +1,23 @@
 package com.tuk.oriddle.domain.user.controller
 
+import com.tuk.oriddle.domain.user.dto.request.UserNicknameUpdateRequest
 import com.tuk.oriddle.domain.user.dto.response.UserInfoResponse
+import com.tuk.oriddle.domain.user.dto.response.UserNicknameUpdateResponse
 import com.tuk.oriddle.domain.user.service.UserQueryService
+import com.tuk.oriddle.domain.user.service.UserService
 import com.tuk.oriddle.global.result.ResultCode
 import com.tuk.oriddle.global.result.ResultResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/user")
-class UserController(private val userQueryService: UserQueryService) {
+class UserController(
+    private val userQueryService: UserQueryService,
+    private val userService: UserService) {
     @Secured("ROLE_USER")
     @GetMapping("/info")
     fun getLoginUserInfo(@AuthenticationPrincipal oauth2User: OAuth2User): ResponseEntity<ResultResponse> {
@@ -22,5 +25,15 @@ class UserController(private val userQueryService: UserQueryService) {
         val user = userQueryService.findById(userId)
         val userInfoResponse = UserInfoResponse.of(user)
         return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_GET_SUCCESS, userInfoResponse))
+    }
+
+    @Secured("ROLE_USER")
+    @PatchMapping("/nickname")
+    fun updateUserNickname(
+        @AuthenticationPrincipal oauth2User: OAuth2User,
+        @RequestBody request: UserNicknameUpdateRequest
+    ): ResponseEntity<ResultResponse> {
+        val userNicknameUpdateResponse: UserNicknameUpdateResponse = userService.updateNickname(oauth2User, request)
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_NICKNAME_UPDATE_SUCCESS, userNicknameUpdateResponse))
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/dto/request/UserNicknameUpdateRequest.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/dto/request/UserNicknameUpdateRequest.kt
@@ -1,0 +1,12 @@
+package com.tuk.oriddle.domain.user.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class UserNicknameUpdateRequest(
+    @NotBlank
+    private val updatedNickname: String
+) {
+    fun getUpdatedNickname(): String {
+        return updatedNickname
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/dto/response/UserNicknameUpdateResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/dto/response/UserNicknameUpdateResponse.kt
@@ -1,0 +1,20 @@
+package com.tuk.oriddle.domain.user.dto.response
+
+import com.tuk.oriddle.domain.user.entity.User
+import java.time.LocalDateTime
+
+data class UserNicknameUpdateResponse(
+    val nickname: String,
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun of(
+            user: User
+        ): UserNicknameUpdateResponse {
+            return UserNicknameUpdateResponse(
+                nickname = user.nickname,
+                updatedAt = user.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/entity/Modifier.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/entity/Modifier.kt
@@ -1,0 +1,16 @@
+package com.tuk.oriddle.domain.user.entity
+
+enum class Modifier(val value: String) {
+    CURIOUS("호기심 많은"),
+    PASSIONATE("열정적인"),
+    CREATIVE("창의적인"),
+    PURE("순수한"),
+    EMOTIONAL("감성적인");
+
+    companion object {
+        fun getRandomModifier(): Modifier {
+            return values().random()
+        }
+    }
+
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/entity/Modifier.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/entity/Modifier.kt
@@ -1,11 +1,17 @@
 package com.tuk.oriddle.domain.user.entity
 
 enum class Modifier(val value: String) {
-    CURIOUS("호기심 많은"),
-    PASSIONATE("열정적인"),
+    CAREFUL("신중한"),
     CREATIVE("창의적인"),
+    CURIOUS("호기심 많은"),
+    EMOTIONAL("감성적인"),
+    FREE("자유로운"),
+    JOLLY("유쾌한"),
+    PASSIONATE("열정적인"),
     PURE("순수한"),
-    EMOTIONAL("감성적인");
+    TOUGH("강인한"),
+    VERSATILE("다재다능한")
+    ;
 
     companion object {
         fun getRandomModifier(): Modifier {

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/entity/User.kt
@@ -16,4 +16,8 @@ class User(
     @Column(name = "nickname", nullable = false)
     var nickname: String = nickname
         private set
+
+    fun updateNickname(updatedNickname: String) {
+        this.nickname = updatedNickname
+    }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
@@ -1,12 +1,17 @@
 package com.tuk.oriddle.domain.user.service
 
+import com.tuk.oriddle.domain.user.entity.Modifier
 import com.tuk.oriddle.domain.user.entity.User
 import com.tuk.oriddle.domain.user.exception.UserNotFoundException
 import com.tuk.oriddle.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
+import kotlin.math.pow
 
 @Service
 class UserQueryService(private val userRepository: UserRepository) {
+    private val randomDigit: Int = 4
+    private val characterName: String = "오리"
+
     fun findById(userId: Long): User {
         return userRepository.findById(userId)
             .orElseThrow { UserNotFoundException() }
@@ -17,6 +22,14 @@ class UserQueryService(private val userRepository: UserRepository) {
     }
 
     fun createByEmail(email: String): User {
-        return userRepository.save(User(email = email, nickname = "기본 이름"))
+        return userRepository.save(User(email = email, nickname = generateRandomNickname(characterName, randomDigit)))
     }
+
+
+    private fun generateRandomNickname(duck: String, numberLength: Int): String {
+        val randomModifier = Modifier.getRandomModifier()
+        val randomNumber = (0 until 10.0.pow(numberLength).toInt()).random().toString().padStart(numberLength, '0')
+        return "${randomModifier.value}$duck$randomNumber"
+    }
+
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service
 
 @Service
 class UserQueryService(private val userRepository: UserRepository) {
-
     fun findById(userId: Long): User {
         return userRepository.findById(userId)
             .orElseThrow { UserNotFoundException() }
@@ -20,5 +19,4 @@ class UserQueryService(private val userRepository: UserRepository) {
     fun save(user: User): User {
         return userRepository.save(user)
     }
-
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
@@ -12,9 +12,11 @@ class UserQueryService(private val userRepository: UserRepository) {
             .orElseThrow { UserNotFoundException() }
     }
 
-    fun findOrCreateUserByEmail(email: String): User {
-        // TODO: nickname 자동 생성 로직 추가하기
-        return userRepository.findByEmail(email)?.let { it }
-            ?: userRepository.save(User(email = email, nickname = "기본 이름"))
+    fun findByEmail(email: String): User? {
+        return userRepository.findByEmail(email)
+    }
+
+    fun createByEmail(email: String): User {
+        return userRepository.save(User(email = email, nickname = "기본 이름"))
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
@@ -1,16 +1,12 @@
 package com.tuk.oriddle.domain.user.service
 
-import com.tuk.oriddle.domain.user.entity.Modifier
 import com.tuk.oriddle.domain.user.entity.User
 import com.tuk.oriddle.domain.user.exception.UserNotFoundException
 import com.tuk.oriddle.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
-import kotlin.math.pow
 
 @Service
 class UserQueryService(private val userRepository: UserRepository) {
-    private val randomDigit: Int = 4
-    private val characterName: String = "오리"
 
     fun findById(userId: Long): User {
         return userRepository.findById(userId)
@@ -21,15 +17,8 @@ class UserQueryService(private val userRepository: UserRepository) {
         return userRepository.findByEmail(email)
     }
 
-    fun createByEmail(email: String): User {
-        return userRepository.save(User(email = email, nickname = generateRandomNickname(characterName, randomDigit)))
-    }
-
-
-    private fun generateRandomNickname(duck: String, numberLength: Int): String {
-        val randomModifier = Modifier.getRandomModifier()
-        val randomNumber = (0 until 10.0.pow(numberLength).toInt()).random().toString().padStart(numberLength, '0')
-        return "${randomModifier.value}$duck$randomNumber"
+    fun save(user: User): User {
+        return userRepository.save(user)
     }
 
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -1,7 +1,11 @@
 package com.tuk.oriddle.domain.user.service
 
+import com.tuk.oriddle.domain.user.dto.request.UserNicknameUpdateRequest
+import com.tuk.oriddle.domain.user.dto.response.UserNicknameUpdateResponse
 import com.tuk.oriddle.domain.user.entity.Modifier
 import com.tuk.oriddle.domain.user.entity.User
+import jakarta.transaction.Transactional
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import kotlin.math.pow
 
@@ -12,6 +16,14 @@ class UserService(private val userQueryService: UserQueryService) {
     fun createByEmail(email: String): User {
         val user = User(email = email, nickname = generateRandomNickname(characterName, randomDigit))
         return userQueryService.save(user)
+    }
+
+    @Transactional
+    fun updateNickname(oauth2User: OAuth2User, request: UserNicknameUpdateRequest): UserNicknameUpdateResponse {
+        val userId = oauth2User.attributes["userId"] as Long
+        val user = userQueryService.findById(userId)
+        user.updateNickname(request.getUpdatedNickname())
+        return UserNicknameUpdateResponse.of(user)
     }
 
     private fun generateRandomNickname(duck: String, numberLength: Int): String {

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -1,0 +1,22 @@
+package com.tuk.oriddle.domain.user.service
+
+import com.tuk.oriddle.domain.user.entity.Modifier
+import com.tuk.oriddle.domain.user.entity.User
+import org.springframework.stereotype.Service
+import kotlin.math.pow
+
+@Service
+class UserService(private val userQueryService: UserQueryService) {
+    private val randomDigit: Int = 4
+    private val characterName: String = "오리"
+    fun createByEmail(email: String): User {
+        val user = User(email = email, nickname = generateRandomNickname(characterName, randomDigit))
+        return userQueryService.save(user)
+    }
+
+    private fun generateRandomNickname(duck: String, numberLength: Int): String {
+        val randomModifier = Modifier.getRandomModifier()
+        val randomNumber = (0 until 10.0.pow(numberLength).toInt()).random().toString().padStart(numberLength, '0')
+        return "${randomModifier.value}$duck$randomNumber"
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -26,6 +26,7 @@ class UserService(private val userQueryService: UserQueryService) {
         return UserNicknameUpdateResponse.of(user)
     }
 
+    // TODO: 닉네임 랜덤 생성 로직 분리
     private fun generateRandomNickname(duck: String, numberLength: Int): String {
         val randomModifier = Modifier.getRandomModifier()
         val randomNumber = (0 until 10.0.pow(numberLength).toInt()).random().toString().padStart(numberLength, '0')

--- a/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomOAuth2UserService.kt
@@ -14,7 +14,7 @@ class CustomOAuth2UserService(private val userQueryService: UserQueryService) : 
         val oauth2User = super.loadUser(userRequest)
 
         val email = oauth2User.attributes["email"] as String
-        val user = userQueryService.findOrCreateUserByEmail(email)
+        val user = userQueryService.findByEmail(email) ?: userQueryService.createByEmail(email)
 
         val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
         val attributes = mapOf("userId" to user.id)

--- a/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomOAuth2UserService.kt
@@ -1,6 +1,7 @@
 package com.tuk.oriddle.global.oauth
 
 import com.tuk.oriddle.domain.user.service.UserQueryService
+import com.tuk.oriddle.domain.user.service.UserService
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
@@ -9,12 +10,15 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 
 @Service
-class CustomOAuth2UserService(private val userQueryService: UserQueryService) : DefaultOAuth2UserService() {
+class CustomOAuth2UserService(
+    private val userQueryService: UserQueryService,
+    private val userService: UserService
+) : DefaultOAuth2UserService() {
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oauth2User = super.loadUser(userRequest)
 
         val email = oauth2User.attributes["email"] as String
-        val user = userQueryService.findByEmail(email) ?: userQueryService.createByEmail(email)
+        val user = userQueryService.findByEmail(email) ?: userService.createByEmail(email)
 
         val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
         val attributes = mapOf("userId" to user.id)

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
@@ -14,4 +14,5 @@ enum class ResultCode(val code: String, val message: String) {
 
     // User (US)
     USER_GET_SUCCESS("US0001", "유저 정보 조회 성공"),
+    USER_NICKNAME_UPDATE_SUCCESS("US0002","유저 닉네임 수정 성공")
 }


### PR DESCRIPTION
## 📢 설명

- 유저 최초 로그인 시, 랜덤 닉네임을 부여되는 로직 구현
- 유저 닉네임 업데이트 API 구현

## ✅ 테스트 목록
- [x] 최초 로그인 시, 형식에 맞는 랜덤 닉네임이 부여되는지 확인
- [ ] 유저 닉네임 업데이트 API가 정상적으로 동작하는지 확인