### PR TITLE
[feat/#42] 퀴즈방 참가자들의 방장 여부 기능 추가 

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/dto/ParticipantInfoGetResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/dto/ParticipantInfoGetResponse.kt
@@ -1,11 +1,13 @@
 package com.tuk.oriddle.domain.participant.dto
 
 import com.tuk.oriddle.domain.participant.entity.Participant
+import com.tuk.oriddle.domain.participant.entity.Role
 
 data class ParticipantInfoGetResponse(
     val userId: Long,
     val position: Int,
-    val nickname: String
+    val nickname: String,
+    val role: Role
 ) {
     companion object {
         fun of(
@@ -14,7 +16,8 @@ data class ParticipantInfoGetResponse(
             return ParticipantInfoGetResponse(
                 userId =  participant.user.id,
                 position = participant.position,
-                nickname = participant.user.nickname
+                nickname = participant.user.nickname,
+                role = participant.role
             )
         }
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/dto/ParticipantInfoGetResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/dto/ParticipantInfoGetResponse.kt
@@ -1,13 +1,12 @@
 package com.tuk.oriddle.domain.participant.dto
 
 import com.tuk.oriddle.domain.participant.entity.Participant
-import com.tuk.oriddle.domain.participant.entity.Role
 
 data class ParticipantInfoGetResponse(
     val userId: Long,
     val position: Int,
     val nickname: String,
-    val role: Role
+    val isHost: Boolean
 ) {
     companion object {
         fun of(
@@ -17,7 +16,7 @@ data class ParticipantInfoGetResponse(
                 userId =  participant.user.id,
                 position = participant.position,
                 nickname = participant.user.nickname,
-                role = participant.role
+                isHost = participant.isHost
             )
         }
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Participant.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Participant.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.*
 class Participant(
     quizRoom: QuizRoom,
     user: User,
-    role: Role
+    isHost: Boolean
 ) : BaseEntity() {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_room_id", nullable = false)
@@ -26,6 +26,6 @@ class Participant(
         private set
 
     @Column(nullable = false)
-    var role: Role = role
+    var isHost: Boolean = isHost
         private set
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Participant.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Participant.kt
@@ -8,7 +8,8 @@ import jakarta.persistence.*
 @Entity
 class Participant(
     quizRoom: QuizRoom,
-    user: User
+    user: User,
+    role: Role
 ) : BaseEntity() {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_room_id", nullable = false)
@@ -22,5 +23,9 @@ class Participant(
 
     @Column(nullable = false)
     var position: Int = quizRoom.getNewPosition()
+        private set
+
+    @Column(nullable = false)
+    var role: Role = role
         private set
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Role.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Role.kt
@@ -1,6 +1,0 @@
-package com.tuk.oriddle.domain.participant.entity
-
-enum class Role {
-    HOST,
-    PARTICIPANT
-}

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Role.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Role.kt
@@ -1,0 +1,6 @@
+package com.tuk.oriddle.domain.participant.entity
+
+enum class Role {
+    HOST,
+    PARTICIPANT
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/exception/ParticipantNotHostException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/exception/ParticipantNotHostException.kt
@@ -1,0 +1,8 @@
+package com.tuk.oriddle.domain.participant.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+class ParticipantNotHostException : BusinessException {
+    constructor() : super(ErrorCode.PARTICIPANT_NOT_HOST)
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/repository/ParticipantRepository.kt
@@ -7,4 +7,5 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
     fun existsByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long): Boolean
     fun deleteByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long)
     fun findByQuizRoomId(quizRoomId: Long): List<Participant>
+    fun findByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long): Participant
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/service/ParticipantQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/service/ParticipantQueryService.kt
@@ -21,4 +21,8 @@ class ParticipantQueryService(private val participantRepository: ParticipantRepo
     fun findByQuizRoomId(roomId: Long): List<Participant> {
         return participantRepository.findByQuizRoomId(roomId)
     }
+
+    fun findByQuizRoomIdAndUserId(roomId: Long, userId: Long): Participant {
+        return participantRepository.findByQuizRoomIdAndUserId(roomId, userId)
+    }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -65,7 +65,6 @@ class QuizRoomController(private val quizRoomService: QuizRoomService) {
         @PathVariable(name = "room-id") roomId: Long,
         @AuthenticationPrincipal oauth2User: OAuth2User
     ): ResponseEntity<ResultResponse> {
-        // TODO: 방장만 시작할 수 있도록 변경
         val userId = oauth2User.name.toLong()
         quizRoomService.startQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_START_SUCCESS))

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -66,7 +66,8 @@ class QuizRoomController(private val quizRoomService: QuizRoomService) {
         @AuthenticationPrincipal oauth2User: OAuth2User
     ): ResponseEntity<ResultResponse> {
         // TODO: 방장만 시작할 수 있도록 변경
-        quizRoomService.startQuizRoom(roomId)
+        val userId = oauth2User.name.toLong()
+        quizRoomService.startQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_START_SUCCESS))
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -3,6 +3,8 @@ package com.tuk.oriddle.domain.quizroom.service
 import com.tuk.oriddle.domain.answer.service.AnswerRedisService
 import com.tuk.oriddle.domain.participant.dto.ParticipantInfoGetResponse
 import com.tuk.oriddle.domain.participant.entity.Participant
+import com.tuk.oriddle.domain.participant.entity.Role
+import com.tuk.oriddle.domain.participant.exception.ParticipantNotHostException
 import com.tuk.oriddle.domain.participant.service.ParticipantQueryService
 import com.tuk.oriddle.domain.participant.service.ParticipantRedisService
 import com.tuk.oriddle.domain.question.entity.Question
@@ -62,7 +64,7 @@ class QuizRoomService(
         val quizRoom = request.toEntity(quiz)
         val user: User = userQueryService.findById(userId)
         quizRoomRepository.save(quizRoom)
-        val participant = Participant(quizRoom, user)
+        val participant = Participant(quizRoom, user, Role.HOST)
         participantQueryService.save(participant)
         quizRoomMessageService.sendQuizRoomJoinMessage(
             quizRoom.id,
@@ -79,7 +81,7 @@ class QuizRoomService(
         val quizRoom = quizRoomQueryService.findById(quizRoomId)
         val user: User = userQueryService.findById(userId)
         checkJoinQuizRoom(quizRoom, user)
-        val participant = Participant(quizRoom, user)
+        val participant = Participant(quizRoom, user, Role.PARTICIPANT)
         participantQueryService.save(participant)
         quizRoomMessageService.sendQuizRoomJoinMessage(
             quizRoomId,
@@ -100,7 +102,11 @@ class QuizRoomService(
     }
 
     @Transactional
-    fun startQuizRoom(quizRoomId: Long) {
+    fun startQuizRoom(quizRoomId: Long, userId: Long) {
+        val participant: Participant = participantQueryService.findByQuizRoomIdAndUserId(quizRoomId, userId)
+        if (participant.role != Role.HOST) {
+            throw ParticipantNotHostException()
+        }
         // TODO: 쿼리 최적화 하기
         val quizRoom = quizRoomQueryService.findById(quizRoomId)
         val questions = questionQueryService.findByQuizId(quizRoom.quiz.id) as MutableList<Question>

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -111,7 +111,6 @@ class QuizRoomService(
         val questions = questionQueryService.findByQuizId(quizRoom.quiz.id) as MutableList<Question>
         val questionCount = questions.size.toLong()
         quizRoomRedisService.saveQuizStatus(quizRoomId, questionCount)
-        println(quizRoom.participants)
         participantRedisService.saveParticipants(quizRoomId, quizRoom.participants)
         for (question in questions) {
             answerRedisService.saveAnswers(quizRoomId, question.number, question.getAnswerSet())

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -3,7 +3,6 @@ package com.tuk.oriddle.domain.quizroom.service
 import com.tuk.oriddle.domain.answer.service.AnswerRedisService
 import com.tuk.oriddle.domain.participant.dto.ParticipantInfoGetResponse
 import com.tuk.oriddle.domain.participant.entity.Participant
-import com.tuk.oriddle.domain.participant.entity.Role
 import com.tuk.oriddle.domain.participant.exception.ParticipantNotHostException
 import com.tuk.oriddle.domain.participant.service.ParticipantQueryService
 import com.tuk.oriddle.domain.participant.service.ParticipantRedisService
@@ -64,7 +63,7 @@ class QuizRoomService(
         val quizRoom = request.toEntity(quiz)
         val user: User = userQueryService.findById(userId)
         quizRoomRepository.save(quizRoom)
-        val participant = Participant(quizRoom, user, Role.HOST)
+        val participant = Participant(quizRoom, user, true)
         participantQueryService.save(participant)
         quizRoomMessageService.sendQuizRoomJoinMessage(
             quizRoom.id,
@@ -81,7 +80,7 @@ class QuizRoomService(
         val quizRoom = quizRoomQueryService.findById(quizRoomId)
         val user: User = userQueryService.findById(userId)
         checkJoinQuizRoom(quizRoom, user)
-        val participant = Participant(quizRoom, user, Role.PARTICIPANT)
+        val participant = Participant(quizRoom, user, false)
         participantQueryService.save(participant)
         quizRoomMessageService.sendQuizRoomJoinMessage(
             quizRoomId,
@@ -104,7 +103,7 @@ class QuizRoomService(
     @Transactional
     fun startQuizRoom(quizRoomId: Long, userId: Long) {
         val participant: Participant = participantQueryService.findByQuizRoomIdAndUserId(quizRoomId, userId)
-        if (participant.role != Role.HOST) {
+        if (!participant.isHost) {
             throw ParticipantNotHostException()
         }
         // TODO: 쿼리 최적화 하기

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
@@ -3,7 +3,6 @@ package com.tuk.oriddle.domain.user.controller
 import com.tuk.oriddle.domain.user.dto.request.UserNicknameUpdateRequest
 import com.tuk.oriddle.domain.user.dto.response.UserInfoResponse
 import com.tuk.oriddle.domain.user.dto.response.UserNicknameUpdateResponse
-import com.tuk.oriddle.domain.user.service.UserQueryService
 import com.tuk.oriddle.domain.user.service.UserService
 import com.tuk.oriddle.global.result.ResultCode
 import com.tuk.oriddle.global.result.ResultResponse
@@ -16,14 +15,12 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/user")
 class UserController(
-    private val userQueryService: UserQueryService,
     private val userService: UserService) {
     @Secured("ROLE_USER")
     @GetMapping("/info")
     fun getLoginUserInfo(@AuthenticationPrincipal oauth2User: OAuth2User): ResponseEntity<ResultResponse> {
         val userId = oauth2User.attributes["userId"] as Long
-        val user = userQueryService.findById(userId)
-        val userInfoResponse = UserInfoResponse.of(user)
+        val userInfoResponse: UserInfoResponse = userService.getLoginUserInfo(userId)
         return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_GET_SUCCESS, userInfoResponse))
     }
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.tuk.oriddle.domain.user.service
 
 import com.tuk.oriddle.domain.user.dto.request.UserNicknameUpdateRequest
+import com.tuk.oriddle.domain.user.dto.response.UserInfoResponse
 import com.tuk.oriddle.domain.user.dto.response.UserNicknameUpdateResponse
 import com.tuk.oriddle.domain.user.entity.Modifier
 import com.tuk.oriddle.domain.user.entity.User
@@ -13,6 +14,11 @@ import kotlin.math.pow
 class UserService(private val userQueryService: UserQueryService) {
     private val randomDigit: Int = 4
     private val characterName: String = "오리"
+    fun getLoginUserInfo(userId: Long): UserInfoResponse {
+        val user = userQueryService.findById(userId)
+        return UserInfoResponse.of(user)
+    }
+
     fun createByEmail(email: String): User {
         val user = User(email = email, nickname = generateRandomNickname(characterName, randomDigit))
         return userQueryService.save(user)

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -21,6 +21,7 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
     PARTICIPANT_NOT_FOUND(400, "PC0001", "참가자를 찾을 수 없음"),
     QUIZ_ROOM_ALREADY_PARTICIPANT(400, "PC0002", "이미 퀴즈방에 참가중"),
     USER_NOT_IN_QUIZ_ROOM(400, "PC0003", "사용자가 퀴즈방에 없음"),
+    PARTICIPANT_NOT_HOST(400, "PC0004", "참가자가 방장이 아님"),
 
     // Question (QS)
     QUESTION_NOT_FOUND_IN_REDIS(400, "QU0001", "질문이 Redis에 없음"),


### PR DESCRIPTION
## 📢 설명
 - 테이블에 참가자의 역할(방장인지, 참가자인지)을 나타내는 필드 추가
 - 퀴즈 시작 API는 퀴즈방의 방장만 호출할 수 있게 리팩토링
 - 퀴즈방 정보 조회 API 응답에 참가자들의 역할 추가

## ✅ 테스트 목록
- [x] 퀴즈방 정보 조회 시, 참가자들의 방장 여부도 응답에 포함되는지 확인
- [x] 방장이 아닌 참가자로 퀴즈 시작을 했을때, 예외처리 되는지 확인