### PR TITLE
[feat/#45] 퀴즈방 채팅 메시징 구현

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomWsController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomWsController.kt
@@ -1,5 +1,6 @@
 package com.tuk.oriddle.domain.quizroom.controller
 
+import com.tuk.oriddle.domain.quizroom.dto.message.ChatReceiveMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.CheckAnswerMessage
 import com.tuk.oriddle.domain.quizroom.service.QuizRoomProgressService
 import com.tuk.oriddle.global.result.ResultCode.*
@@ -21,4 +22,15 @@ class QuizRoomWsController(private val quizRoomProgressService: QuizRoomProgress
         val userId = (headerAccessor.sessionAttributes?.get("id") as String).toLong()
         quizRoomProgressService.checkAnswer(quizRoomId, message, userId)
     }
+
+    @MessageMapping("quiz-room/{quizRoomId}/chat")
+    fun sendChatMessage(
+            @DestinationVariable("quizRoomId") quizRoomId: Long,
+            @Payload message: ChatReceiveMessage,
+            headerAccessor: SimpMessageHeaderAccessor
+    ) {
+        val userId = (headerAccessor.sessionAttributes?.get("id") as String).toLong()
+        quizRoomProgressService.sendChatMessage(quizRoomId, message, userId)
+    }
+
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/ChatReceiveMessage.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/ChatReceiveMessage.kt
@@ -1,0 +1,5 @@
+package com.tuk.oriddle.domain.quizroom.dto.message
+
+data class ChatReceiveMessage(
+    val content: String
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/ChatSendMessage.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/message/ChatSendMessage.kt
@@ -1,0 +1,6 @@
+package com.tuk.oriddle.domain.quizroom.dto.message
+
+data class ChatSendMessage(
+    val nickname: String,
+    val content: String
+)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
@@ -46,6 +46,10 @@ class QuizRoomMessageService(
         sendMessage("finish", quizRoomId, QuizRoomFinishMessage(quizRoomId))
     }
 
+    fun sendChatMessage(quizRoomId: Long, message: ChatSendMessage) {
+        sendMessage("chat", quizRoomId, message)
+    }
+
     private fun sendMessage(topic: String, quizRoomId: Long, message: Any) {
         val destination = "/topic/quiz-room/$quizRoomId/$topic"
         messagingTemplate.convertAndSend(destination, message)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomProgressService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomProgressService.kt
@@ -7,9 +7,12 @@ import com.tuk.oriddle.domain.participant.service.ParticipantRedisService
 import com.tuk.oriddle.domain.question.entity.Question
 import com.tuk.oriddle.domain.question.service.QuestionQueryService
 import com.tuk.oriddle.domain.question.service.QuestionRedisService
+import com.tuk.oriddle.domain.quizroom.dto.message.ChatReceiveMessage
+import com.tuk.oriddle.domain.quizroom.dto.message.ChatSendMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.CheckAnswerMessage
 import com.tuk.oriddle.domain.quizroom.entity.QuizRoomProgressStatus
 import com.tuk.oriddle.domain.quizroom.scheduler.QuizRoomProgressScheduler
+import com.tuk.oriddle.domain.user.service.UserQueryService
 import org.springframework.stereotype.Service
 
 @Service
@@ -22,7 +25,8 @@ class QuizRoomProgressService(
     private val questionRedisService: QuestionRedisService,
     private val quizRoomMessageService: QuizRoomMessageService,
     private val quizRoomProgressScheduler: QuizRoomProgressScheduler,
-    private val participantQueryService: ParticipantQueryService
+    private val participantQueryService: ParticipantQueryService,
+    private val userQueryService: UserQueryService
 ) {
     fun startQuizRoom(quizRoomId: Long, userId: Long) {
         val isNotHost =
@@ -70,5 +74,11 @@ class QuizRoomProgressService(
             quizRoomRedisService.saveQuizStatus(status.getNextQuestionStatus())
             quizRoomProgressScheduler.scheduleNextQuestionPublish(quizRoomId)
         }
+    }
+
+    fun sendChatMessage(quizRoomId: Long, message: ChatReceiveMessage, userId: Long) {
+        val user = userQueryService.findById(userId)
+        val sendMessage = ChatSendMessage(user.nickname, message.content)
+        quizRoomMessageService.sendChatMessage(quizRoomId, sendMessage)
     }
 }


### PR DESCRIPTION
## 📢 설명
한 퀴즈방 내에서 참가자들끼리 채팅을 주고 받는 기능을 웹 소켓 메시징으로 구현

## ✅ 테스트 목록
- [x] 2개의 스웨거에서 각각 별도의 계정으로 로그인 후, 같은 퀴즈방에 참가
- [x] postman의 웹소켓 창을 2개 띄워놓고, 각각 로그인한 유저로 소켓 연결

- 연결 

```
CONNECT
accept-version:1.1,1.0
heart-beat:10000,10000

{{NULL_CHAR}}
```




- [x] 각 소켓에서 채팅 구독

- 채팅 구독

```
SUBSCRIBE
id:sub-8
destination:/topic/quiz-room/1/chat

{{NULL_CHAR}}
```
- [x] 한 쪽 소켓에서 채팅 전송

- 채팅 전송

```
SEND
destination:/app/quiz-room/1/chat
content-type:application/json

{"content": "반갑습니다"}

{{NULL_CHAR}}
```

- [x] 각 소켓에서 보낸 유저의 닉네임이 포함된 채팅메시지가 수신됐는지 확인

