### PR TITLE
[refactor/#47] 로그인한 userId 불러오는 방식 개선, 코드 포매팅 및 리팩토링

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/OriddleApplication.kt
+++ b/src/main/kotlin/com/tuk/oriddle/OriddleApplication.kt
@@ -11,5 +11,5 @@ import org.springframework.scheduling.annotation.EnableScheduling
 class OriddleApplication
 
 fun main(args: Array<String>) {
-	runApplication<OriddleApplication>(*args)
+    runApplication<OriddleApplication>(*args)
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/dto/ParticipantInfoGetResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/dto/ParticipantInfoGetResponse.kt
@@ -13,7 +13,7 @@ data class ParticipantInfoGetResponse(
             participant: Participant
         ): ParticipantInfoGetResponse {
             return ParticipantInfoGetResponse(
-                userId =  participant.user.id,
+                userId = participant.user.id,
                 position = participant.position,
                 nickname = participant.user.nickname,
                 isHost = participant.isHost

--- a/src/main/kotlin/com/tuk/oriddle/domain/quiz/controller/QuizController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quiz/controller/QuizController.kt
@@ -25,8 +25,8 @@ class QuizController(private val quizService: QuizService) {
         @PathVariable page: Int,
         @RequestParam(defaultValue = "20") pageSize: Int
     ): ResponseEntity<ResultResponse> {
-        val pageReqeust: PageRequest = PageRequest.of(page, pageSize, Sort.by("id").descending());
-        val quizzes: QuizListResponse = quizService.getQuizzesWithPaging(pageReqeust)
+        val pageRequest: PageRequest = PageRequest.of(page, pageSize, Sort.by("id").descending());
+        val quizzes: QuizListResponse = quizService.getQuizzesWithPaging(pageRequest)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_PAGING_GET_SUCCESS, quizzes))
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -6,13 +6,12 @@ import com.tuk.oriddle.domain.quizroom.dto.response.QuizRoomInfoGetResponse
 import com.tuk.oriddle.domain.quizroom.dto.response.QuizRoomJoinResponse
 import com.tuk.oriddle.domain.quizroom.service.QuizRoomProgressService
 import com.tuk.oriddle.domain.quizroom.service.QuizRoomService
+import com.tuk.oriddle.global.annotation.LoginUser
 import com.tuk.oriddle.global.result.ResultCode.*
 import com.tuk.oriddle.global.result.ResultResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -34,10 +33,8 @@ class QuizRoomController(
     @PostMapping
     fun createQuizRoom(
         @Valid @RequestBody request: QuizRoomCreateRequest,
-        @AuthenticationPrincipal oauth2User: OAuth2User
+        @LoginUser userId: Long
     ): ResponseEntity<ResultResponse> {
-        // TODO: 인증 정보 가져오는 로직 수정
-        val userId = oauth2User.name.toLong()
         val response: QuizRoomCreateResponse = quizRoomService.createQuizRoom(request, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_CREATE_SUCCESS, response))
     }
@@ -46,10 +43,8 @@ class QuizRoomController(
     @PostMapping("/{room-id}/join")
     fun joinQuizRoom(
         @PathVariable(name = "room-id") roomId: Long,
-        @AuthenticationPrincipal oauth2User: OAuth2User
+        @LoginUser userId: Long
     ): ResponseEntity<ResultResponse> {
-        // TODO: 인증 정보 가져오는 로직 수정
-        val userId = oauth2User.name.toLong()
         val response: QuizRoomJoinResponse = quizRoomService.joinQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_JOIN_SUCCESS, response))
     }
@@ -58,10 +53,8 @@ class QuizRoomController(
     @PostMapping("/{room-id}/leave")
     fun leaveQuizRoom(
         @PathVariable(name = "room-id") roomId: Long,
-        @AuthenticationPrincipal oauth2User: OAuth2User
+        @LoginUser userId: Long
     ): ResponseEntity<ResultResponse> {
-        // TODO: 인증 정보 가져오는 로직 수정
-        val userId = oauth2User.name.toLong()
         quizRoomService.leaveQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_LEAVE_SUCCESS))
     }
@@ -70,9 +63,8 @@ class QuizRoomController(
     @PostMapping("/{room-id}/start")
     fun startQuizRoom(
         @PathVariable(name = "room-id") roomId: Long,
-        @AuthenticationPrincipal oauth2User: OAuth2User
+        @LoginUser userId: Long
     ): ResponseEntity<ResultResponse> {
-        val userId = oauth2User.name.toLong()
         quizRoomProgressService.startQuizRoom(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_START_SUCCESS))
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomWsController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomWsController.kt
@@ -25,12 +25,11 @@ class QuizRoomWsController(private val quizRoomProgressService: QuizRoomProgress
 
     @MessageMapping("quiz-room/{quizRoomId}/chat")
     fun sendChatMessage(
-            @DestinationVariable("quizRoomId") quizRoomId: Long,
-            @Payload message: ChatReceiveMessage,
-            headerAccessor: SimpMessageHeaderAccessor
+        @DestinationVariable("quizRoomId") quizRoomId: Long,
+        @Payload message: ChatReceiveMessage,
+        headerAccessor: SimpMessageHeaderAccessor
     ) {
         val userId = (headerAccessor.sessionAttributes?.get("id") as String).toLong()
         quizRoomProgressService.sendChatMessage(quizRoomId, message, userId)
     }
-
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
@@ -16,6 +16,3 @@ data class QuizRoomCreateRequest(
         return QuizRoom(this.title, this.maxParticipant, quiz)
     }
 }
-
-
-

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomMessageService.kt
@@ -33,7 +33,6 @@ class QuizRoomMessageService(
         answerMessage: CheckAnswerMessage,
         score: Int
     ) {
-        // TODO: 다음 문제로 넘어가는 처리 구현
         val correctMessage = AnswerCorrectMessage(userId, answerMessage.answer, score)
         sendMessage("answer", quizRoomId, correctMessage)
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/user")
 class UserController(
-    private val userService: UserService) {
+    private val userService: UserService
+) {
     @Secured("ROLE_USER")
     @GetMapping("/info")
     fun getLoginUserInfo(@LoginUser userId: Long): ResponseEntity<ResultResponse> {
@@ -28,7 +29,13 @@ class UserController(
         @LoginUser userId: Long,
         @RequestBody request: UserNicknameUpdateRequest
     ): ResponseEntity<ResultResponse> {
-        val userNicknameUpdateResponse: UserNicknameUpdateResponse = userService.updateNickname(userId, request)
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_NICKNAME_UPDATE_SUCCESS, userNicknameUpdateResponse))
+        val userNicknameUpdateResponse: UserNicknameUpdateResponse =
+            userService.updateNickname(userId, request)
+        return ResponseEntity.ok(
+            ResultResponse.of(
+                ResultCode.USER_NICKNAME_UPDATE_SUCCESS,
+                userNicknameUpdateResponse
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/controller/UserController.kt
@@ -4,12 +4,11 @@ import com.tuk.oriddle.domain.user.dto.request.UserNicknameUpdateRequest
 import com.tuk.oriddle.domain.user.dto.response.UserInfoResponse
 import com.tuk.oriddle.domain.user.dto.response.UserNicknameUpdateResponse
 import com.tuk.oriddle.domain.user.service.UserService
+import com.tuk.oriddle.global.annotation.LoginUser
 import com.tuk.oriddle.global.result.ResultCode
 import com.tuk.oriddle.global.result.ResultResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -18,8 +17,7 @@ class UserController(
     private val userService: UserService) {
     @Secured("ROLE_USER")
     @GetMapping("/info")
-    fun getLoginUserInfo(@AuthenticationPrincipal oauth2User: OAuth2User): ResponseEntity<ResultResponse> {
-        val userId = oauth2User.attributes["userId"] as Long
+    fun getLoginUserInfo(@LoginUser userId: Long): ResponseEntity<ResultResponse> {
         val userInfoResponse: UserInfoResponse = userService.getLoginUserInfo(userId)
         return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_GET_SUCCESS, userInfoResponse))
     }
@@ -27,10 +25,10 @@ class UserController(
     @Secured("ROLE_USER")
     @PatchMapping("/nickname")
     fun updateUserNickname(
-        @AuthenticationPrincipal oauth2User: OAuth2User,
+        @LoginUser userId: Long,
         @RequestBody request: UserNicknameUpdateRequest
     ): ResponseEntity<ResultResponse> {
-        val userNicknameUpdateResponse: UserNicknameUpdateResponse = userService.updateNickname(oauth2User, request)
+        val userNicknameUpdateResponse: UserNicknameUpdateResponse = userService.updateNickname(userId, request)
         return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_NICKNAME_UPDATE_SUCCESS, userNicknameUpdateResponse))
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/entity/Modifier.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/entity/Modifier.kt
@@ -18,5 +18,4 @@ enum class Modifier(val value: String) {
             return values().random()
         }
     }
-
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserQueryService.kt
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Service
 @Service
 class UserQueryService(private val userRepository: UserRepository) {
     fun findById(userId: Long): User {
-        return userRepository.findById(userId)
-            .orElseThrow { UserNotFoundException() }
+        return userRepository.findById(userId).orElseThrow { UserNotFoundException() }
     }
 
     fun findByEmail(email: String): User? {

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -6,7 +6,6 @@ import com.tuk.oriddle.domain.user.dto.response.UserNicknameUpdateResponse
 import com.tuk.oriddle.domain.user.entity.Modifier
 import com.tuk.oriddle.domain.user.entity.User
 import jakarta.transaction.Transactional
-import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import kotlin.math.pow
 
@@ -25,8 +24,7 @@ class UserService(private val userQueryService: UserQueryService) {
     }
 
     @Transactional
-    fun updateNickname(oauth2User: OAuth2User, request: UserNicknameUpdateRequest): UserNicknameUpdateResponse {
-        val userId = oauth2User.attributes["userId"] as Long
+    fun updateNickname(userId: Long, request: UserNicknameUpdateRequest): UserNicknameUpdateResponse {
         val user = userQueryService.findById(userId)
         user.updateNickname(request.getUpdatedNickname())
         return UserNicknameUpdateResponse.of(user)

--- a/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/user/service/UserService.kt
@@ -19,12 +19,15 @@ class UserService(private val userQueryService: UserQueryService) {
     }
 
     fun createByEmail(email: String): User {
-        val user = User(email = email, nickname = generateRandomNickname(characterName, randomDigit))
+        val user =
+            User(email = email, nickname = generateRandomNickname(characterName, randomDigit))
         return userQueryService.save(user)
     }
 
     @Transactional
-    fun updateNickname(userId: Long, request: UserNicknameUpdateRequest): UserNicknameUpdateResponse {
+    fun updateNickname(
+        userId: Long, request: UserNicknameUpdateRequest
+    ): UserNicknameUpdateResponse {
         val user = userQueryService.findById(userId)
         user.updateNickname(request.getUpdatedNickname())
         return UserNicknameUpdateResponse.of(user)
@@ -33,7 +36,8 @@ class UserService(private val userQueryService: UserQueryService) {
     // TODO: 닉네임 랜덤 생성 로직 분리
     private fun generateRandomNickname(duck: String, numberLength: Int): String {
         val randomModifier = Modifier.getRandomModifier()
-        val randomNumber = (0 until 10.0.pow(numberLength).toInt()).random().toString().padStart(numberLength, '0')
+        val randomNumber =
+            (0 until 10.0.pow(numberLength).toInt()).random().toString().padStart(numberLength, '0')
         return "${randomModifier.value}$duck$randomNumber"
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/annotation/LoginUser.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/annotation/LoginUser.kt
@@ -1,0 +1,8 @@
+package com.tuk.oriddle.global.annotation
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@AuthenticationPrincipal
+annotation class LoginUser()

--- a/src/main/kotlin/com/tuk/oriddle/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/config/WebMvcConfig.kt
@@ -1,14 +1,17 @@
 package com.tuk.oriddle.global.config
 
+import com.tuk.oriddle.global.resolver.LoginUserArgumentResolver
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebMvcConfig(
     @Value("\${frontend.base-url}")
-    private val baseUrl: String
+    private val baseUrl: String,
+    private val loginUserArgumentResolver: LoginUserArgumentResolver
 ) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
@@ -16,5 +19,9 @@ class WebMvcConfig(
             .allowedMethods("GET", "POST", "PUT", "DELETE")
             .allowCredentials(true)
             .allowedHeaders("*");
+    }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(loginUserArgumentResolver)
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/GlobalExceptionHandler.kt
@@ -34,7 +34,7 @@ class GlobalExceptionHandler {
         e: AccessDeniedException,
         request: HttpServletRequest
     ): ResponseEntity<ErrorResponse?>? {
-        log.warn("${e.message}: [${request.method}] ${request.requestURI}")
+        log.warn("[${request.method}] ${request.requestURI}: ${ErrorCode.ACCESS_DENIED.message}")
         val response = ErrorResponse.of(ErrorCode.ACCESS_DENIED)
         return ResponseEntity(response, HttpStatus.UNAUTHORIZED)
     }

--- a/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/oauth/CustomAuthenticationSuccessHandler.kt
@@ -20,8 +20,7 @@ class CustomAuthenticationSuccessHandler : AuthenticationSuccessHandler {
 
         if (redirectUrl != null) {
             response.sendRedirect(redirectUrl)
-        }
-        else {
+        } else {
             response.sendRedirect("/")
         }
     }

--- a/src/main/kotlin/com/tuk/oriddle/global/resolver/LoginUserArgumentResolver.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/resolver/LoginUserArgumentResolver.kt
@@ -1,0 +1,38 @@
+package com.tuk.oriddle.global.resolver
+
+import com.tuk.oriddle.global.annotation.LoginUser
+import com.tuk.oriddle.global.error.ErrorCode
+import org.springframework.core.MethodParameter
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class LoginUserArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        val hasLoginUserAnnotation = parameter.getParameterAnnotation(LoginUser::class.java) != null
+        val isLongType = Long::class.java.isAssignableFrom(parameter.parameterType)
+        return hasLoginUserAnnotation && isLongType
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val principal = authentication.principal
+
+        if (principal is OAuth2User) {
+            return principal.attributes["userId"] as Long
+        }
+
+        throw AccessDeniedException(ErrorCode.ACCESS_DENIED.message)
+    }
+}

--- a/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/result/ResultCode.kt
@@ -9,10 +9,10 @@ enum class ResultCode(val code: String, val message: String) {
     QUIZ_ROOM_CREATE_SUCCESS("QR0001", "퀴즈방 생성 성공"),
     QUIZ_ROOM_JOIN_SUCCESS("QR0002", "퀴즈방 참여 성공"),
     QUIZ_ROOM_LEAVE_SUCCESS("QR0003", "퀴즈방 퇴장 성공"),
-    QUIZ_ROOM_GET_INFO_SUCCESS("QR0004","퀴즈방 정보 조회 성공"),
+    QUIZ_ROOM_GET_INFO_SUCCESS("QR0004", "퀴즈방 정보 조회 성공"),
     QUIZ_ROOM_START_SUCCESS("QR0005", "퀴즈 시작 성공"),
 
     // User (US)
     USER_GET_SUCCESS("US0001", "유저 정보 조회 성공"),
-    USER_NICKNAME_UPDATE_SUCCESS("US0002","유저 닉네임 수정 성공")
+    USER_NICKNAME_UPDATE_SUCCESS("US0002", "유저 닉네임 수정 성공")
 }


### PR DESCRIPTION
## 📢 설명
- LoginUser 어노테이션과 Resolver를 통해 로그인 정보를 가져와서 매개변수에 주입해주는 기능 구현
- LoginUser 를 사용하도록 리팩토링
- 포매팅, 주석 제거 진행

## ✅ 테스트 목록
- [x] 기존에 로그인한 유저의 정보를 이용하던 API 정상적으로 작동하는지 확인