### PR TITLE
[feat/#50] 퀴즈방 생성 시 RequestBody에 대한 유효성 검증 추가

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/dto/request/QuizRoomCreateRequest.kt
@@ -3,13 +3,15 @@ package com.tuk.oriddle.domain.quizroom.dto.request
 import com.tuk.oriddle.domain.quiz.entity.Quiz
 import com.tuk.oriddle.domain.quizroom.entity.QuizRoom
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
+import org.hibernate.validator.constraints.Length
+import org.hibernate.validator.constraints.Range
 
-data class QuizRoomCreateRequest(
+data class QuizRoomCreateRequest constructor(
     val quizId: Long,
-    @field:NotBlank(message = "title은 비어 있을 수 없습니다.")
+    @field:NotBlank
+    @field:Length(max = 20)
     val title: String,
-    @field:NotNull(message = "maxParticipant는 비어 있을 수 없습니다.")
+    @field:Range(min = 2, max = 8)
     val maxParticipant: Int,
 ) {
     fun toEntity(quiz: Quiz): QuizRoom {

--- a/src/main/kotlin/com/tuk/oriddle/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/config/WebMvcConfig.kt
@@ -1,8 +1,12 @@
 package com.tuk.oriddle.global.config
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.tuk.oriddle.global.resolver.LoginUserArgumentResolver
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -23,5 +27,14 @@ class WebMvcConfig(
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(loginUserArgumentResolver)
+    }
+
+    override fun extendMessageConverters(converters: List<HttpMessageConverter<*>?>) {
+        for (converter in converters) {
+            if (converter is MappingJackson2HttpMessageConverter) {
+                val mapper: ObjectMapper = converter.objectMapper
+                mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorResponse.kt
@@ -27,6 +27,16 @@ data class ErrorResponse private constructor(
             businessCode = code.code,
             errorMessage = code.message
         )
+
+        fun fieldNullErrorResponse(fieldName: String): ErrorResponse = ErrorResponse(
+            businessCode = ErrorCode.INPUT_INVALID_VALUE.code,
+            errorMessage = "${fieldName}이(가) null 입니다."
+        )
+
+        fun fieldTypeErrorResponse(fieldName: String, type: String): ErrorResponse = ErrorResponse(
+            businessCode = ErrorCode.INPUT_INVALID_VALUE.code,
+            errorMessage = "${fieldName}의 type은 ${type}입니다."
+        )
     }
 
     data class FieldError(


### PR DESCRIPTION
## 📢 설명
- RequestBody 유효성 검증 시 null이거나 type이 안맞을 때 발생하는 예외 핸들링 하는 기능 추가
- QuizRoomCreateRequest에 유효성 검증 로직들 추가

## ✅ 테스트 목록
- [x] 퀴즈방 생성 시 requestBody에 특정 값을 넣지 않을 때 응답으로 `{fieldName}이(가) null입니다.`가 오는지 확인
- [x] title을 공백으로 넣었을 때, 20자 초과로 넣었을 때, maxParticipant를 2보다 낮거나 8보다 크게 넣었을 때 에러 메시지가 잘 오는지 확인