### PR TITLE
[refactor/#54] 유저와 참가자 도메인의 연관관계 수정 및 퀴즈방 관련 API 예외처리 로직 추가

### DIFF
--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Participant.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/entity/Participant.kt
@@ -16,8 +16,8 @@ class Participant(
     var quizRoom: QuizRoom = quizRoom
         private set
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     var user: User = user
         private set
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/repository/ParticipantRepository.kt
@@ -8,4 +8,5 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
     fun deleteByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long)
     fun findByQuizRoomId(quizRoomId: Long): List<Participant>
     fun findByQuizRoomIdAndUserId(quizRoomId: Long, userId: Long): Participant
+    fun existsByUserId(userId: Long): Boolean
 }

--- a/src/main/kotlin/com/tuk/oriddle/domain/participant/service/ParticipantQueryService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/participant/service/ParticipantQueryService.kt
@@ -22,6 +22,10 @@ class ParticipantQueryService(private val participantRepository: ParticipantRepo
         return participantRepository.findByQuizRoomId(roomId)
     }
 
+    fun checkUserHasParticipating(userId: Long): Boolean {
+        return participantRepository.existsByUserId(userId)
+    }
+
     fun findByQuizRoomIdAndUserId(roomId: Long, userId: Long): Participant {
         return participantRepository.findByQuizRoomIdAndUserId(roomId, userId)
     }

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/QuizRoomController.kt
@@ -24,9 +24,10 @@ class QuizRoomController(
     @Secured("ROLE_USER")
     @GetMapping("/{room-id}")
     override fun getQuizRoomInfo(
-        @PathVariable(name = "room-id") roomId: Long
+        @PathVariable(name = "room-id") roomId: Long,
+        @LoginUser userId: Long
     ): ResponseEntity<ResultResponse> {
-        val response: QuizRoomInfoGetResponse = quizRoomService.getQuizRoomInfo(roomId)
+        val response: QuizRoomInfoGetResponse = quizRoomService.getQuizRoomInfo(roomId, userId)
         return ResponseEntity.ok(ResultResponse.of(QUIZ_ROOM_GET_INFO_SUCCESS, response))
     }
 

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/doc/QuizRoomApiDoc.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/controller/doc/QuizRoomApiDoc.kt
@@ -30,7 +30,8 @@ interface QuizRoomApiDoc {
             )]
         )]
     )
-    fun getQuizRoomInfo(@PathVariable(name = "room-id") roomId: Long): ResponseEntity<ResultResponse>
+    fun getQuizRoomInfo(@PathVariable(name = "room-id") roomId: Long, @LoginUser userId:  Long
+    ): ResponseEntity<ResultResponse>
 
     @Operation(summary = "퀴즈방 생성", security = [SecurityRequirement(name = "ROLE_USER")])
     @ApiResponses(

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/UserAlreadyInQuizRoomException.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/exception/UserAlreadyInQuizRoomException.kt
@@ -1,0 +1,8 @@
+package com.tuk.oriddle.domain.quizroom.exception
+
+import com.tuk.oriddle.global.error.ErrorCode
+import com.tuk.oriddle.global.error.exception.BusinessException
+
+class UserAlreadyInQuizRoomException : BusinessException {
+    constructor() : super(ErrorCode.USER_ALREADY_IN_QUIZ_ROOM)
+}

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomProgressService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomProgressService.kt
@@ -11,6 +11,7 @@ import com.tuk.oriddle.domain.quizroom.dto.message.ChatReceiveMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.ChatSendMessage
 import com.tuk.oriddle.domain.quizroom.dto.message.CheckAnswerMessage
 import com.tuk.oriddle.domain.quizroom.entity.QuizRoomProgressStatus
+import com.tuk.oriddle.domain.quizroom.exception.UserNotInQuizRoomException
 import com.tuk.oriddle.domain.quizroom.scheduler.QuizRoomProgressScheduler
 import com.tuk.oriddle.domain.user.service.UserQueryService
 import org.springframework.stereotype.Service
@@ -29,6 +30,9 @@ class QuizRoomProgressService(
     private val userQueryService: UserQueryService
 ) {
     fun startQuizRoom(quizRoomId: Long, userId: Long) {
+        if (!participantQueryService.isUserAlreadyParticipant(quizRoomId, userId)) {
+            throw UserNotInQuizRoomException()
+        }
         val isNotHost =
             !participantQueryService.findByQuizRoomIdAndUserId(quizRoomId, userId).isHost
         if (isNotHost) {

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -88,6 +88,12 @@ class QuizRoomService(
     private fun checkJoinQuizRoom(quizRoom: QuizRoom, user: User) {
         checkUserAlreadyParticipant(quizRoom.id, user.id)
         checkQuizRoomFull(quizRoom)
+        checkOtherQuizRoomParticipation(user.id)
+    }
+
+    private fun checkOtherQuizRoomParticipation(userId: Long) {
+        if (participantQueryService.checkUserHasParticipating(userId))
+            throw UserAlreadyInQuizRoomException()
     }
 
     private fun checkUserAlreadyParticipant(quizRoomId: Long, userId: Long) {

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -2,7 +2,6 @@ package com.tuk.oriddle.domain.quizroom.service
 
 import com.tuk.oriddle.domain.participant.dto.ParticipantInfoGetResponse
 import com.tuk.oriddle.domain.participant.entity.Participant
-import com.tuk.oriddle.domain.participant.exception.ParticipantNotHostException
 import com.tuk.oriddle.domain.participant.service.ParticipantQueryService
 import com.tuk.oriddle.domain.quiz.entity.Quiz
 import com.tuk.oriddle.domain.quiz.service.QuizQueryService
@@ -13,6 +12,7 @@ import com.tuk.oriddle.domain.quizroom.dto.response.QuizRoomJoinResponse
 import com.tuk.oriddle.domain.quizroom.entity.QuizRoom
 import com.tuk.oriddle.domain.quizroom.exception.QuizRoomAlreadyParticipantException
 import com.tuk.oriddle.domain.quizroom.exception.QuizRoomFullException
+import com.tuk.oriddle.domain.quizroom.exception.UserAlreadyInQuizRoomException
 import com.tuk.oriddle.domain.quizroom.exception.UserNotInQuizRoomException
 import com.tuk.oriddle.domain.user.entity.User
 import com.tuk.oriddle.domain.user.service.UserQueryService
@@ -27,7 +27,11 @@ class QuizRoomService(
     private val quizRoomMessageService: QuizRoomMessageService,
     private val quizRoomQueryService: QuizRoomQueryService,
 ) {
-    fun getQuizRoomInfo(quizRoomId: Long): QuizRoomInfoGetResponse {
+    fun getQuizRoomInfo(quizRoomId: Long, userId: Long): QuizRoomInfoGetResponse {
+        if (!participantQueryService.isUserAlreadyParticipant(quizRoomId, userId)) {
+            throw UserNotInQuizRoomException()
+        }
+        participantQueryService.findByQuizRoomIdAndUserId(quizRoomId, userId)
         val quizRoom: QuizRoom = quizRoomQueryService.findById(quizRoomId)
         val participants: List<Participant> = participantQueryService.findByQuizRoomId(quizRoomId)
         val participantsInfo: List<ParticipantInfoGetResponse> = participants

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -44,6 +44,7 @@ class QuizRoomService(
     fun createQuizRoom(
         request: QuizRoomCreateRequest, userId: Long
     ): QuizRoomCreateResponse {
+        checkOtherQuizRoomParticipation(userId)
         val quiz: Quiz = quizQueryService.findById(request.quizId)
         val quizRoom = request.toEntity(quiz)
         val user: User = userQueryService.findById(userId)

--- a/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
+++ b/src/main/kotlin/com/tuk/oriddle/domain/quizroom/service/QuizRoomService.kt
@@ -63,7 +63,7 @@ class QuizRoomService(
     fun joinQuizRoom(quizRoomId: Long, userId: Long): QuizRoomJoinResponse {
         // TODO: 쿼리 최적화 필요
         val quizRoom = quizRoomQueryService.findById(quizRoomId)
-        val user: User = userQueryService.findById(userId)
+        val user = userQueryService.findById(userId)
         checkJoinQuizRoom(quizRoom, user)
         val participant = Participant(quizRoom, user, false)
         participantQueryService.save(participant)

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -19,10 +19,10 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
 
     // Participant (PC)
     PARTICIPANT_NOT_FOUND(400, "PC0001", "참가자를 찾을 수 없음"),
-    QUIZ_ROOM_ALREADY_PARTICIPANT(400, "PC0002", "이미 퀴즈방에 참가중"),
+    QUIZ_ROOM_ALREADY_PARTICIPANT(400, "PC0002", "이미 현재 퀴즈방에 참가중임"),
     USER_NOT_IN_QUIZ_ROOM(400, "PC0003", "유저가 퀴즈방에 없음"),
     PARTICIPANT_NOT_HOST(400, "PC0004", "참가자가 방장이 아님"),
-    USER_ALREADY_IN_QUIZ_ROOM(400, "PC0005", "유저가 이미 퀴즈방에 있음"),
+    USER_ALREADY_IN_QUIZ_ROOM(400, "PC0005", "유저가 이미 다른 퀴즈방에 참가중임"),
 
     // Question (QS)
     QUESTION_NOT_FOUND_IN_REDIS(400, "QU0001", "질문이 Redis에 없음"),

--- a/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/tuk/oriddle/global/error/ErrorCode.kt
@@ -20,8 +20,9 @@ enum class ErrorCode(val status: Int, val code: String, val message: String) {
     // Participant (PC)
     PARTICIPANT_NOT_FOUND(400, "PC0001", "참가자를 찾을 수 없음"),
     QUIZ_ROOM_ALREADY_PARTICIPANT(400, "PC0002", "이미 퀴즈방에 참가중"),
-    USER_NOT_IN_QUIZ_ROOM(400, "PC0003", "사용자가 퀴즈방에 없음"),
+    USER_NOT_IN_QUIZ_ROOM(400, "PC0003", "유저가 퀴즈방에 없음"),
     PARTICIPANT_NOT_HOST(400, "PC0004", "참가자가 방장이 아님"),
+    USER_ALREADY_IN_QUIZ_ROOM(400, "PC0005", "유저가 이미 퀴즈방에 있음"),
 
     // Question (QS)
     QUESTION_NOT_FOUND_IN_REDIS(400, "QU0001", "질문이 Redis에 없음"),


### PR DESCRIPTION
## 📢 설명
 - [user] - [participant] 1:N 관계에서 1:1 관계로 수정
 - 퀴즈방 정보 조회 시, 해당 퀴즈방에 현재 유저가 참가하고 있지 않으면 예외 처리
 - 퀴즈방 참가 시, 이미 다른 퀴즈방에 참가중이면 예외
 - 퀴즈방 시작 시, 해당 퀴즈방에 현재 유저가 참가하고 있지 않으면 예외 처리

## ✅ 테스트 목록
- [x] application.yml의 ddl-auto 설정을 create로 실행했을때, 오류가 없이 실행이 되는지 확인
- [x] 참가중이지 않은 퀴즈방의 정보를 조회했을때, 예외 처리가 발생하는지 확인
- [x] 다른 퀴즈방에 참가한 상태에서, 어떤 퀴즈방을 참가하려고 했을때, 예외 처리가 발생하는지 확인
- [x] 참가중이지 않은 퀴즈방을 시작했을때, 예외 처리가 발생하는지 확인